### PR TITLE
feat(families): implement full feature with E2E test setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,18 @@ DB_PORT=5432
 DB_USER=klankern_user
 DB_PASSWORD=klankern_password
 DB_NAME=klankern_db
+
+#----------------------------------------------------------------------
+# Email (MailerSend SMTP)
+#----------------------------------------------------------------------
+MAIL_FROM_ADDRESS="noreply@yourdomain.com"
+MAILERSEND_SMTP_HOST="smtp.mailersend.net"
+MAILERSEND_SMTP_PORT="587"
+MAILERSEND_SMTP_SECURE="false"
+MAILERSEND_SMTP_USER="your_mailersend_username"
+MAILERSEND_SMTP_PASS="your_mailersend_password"
+
+#----------------------------------------------------------------------
+# Application URL
+#----------------------------------------------------------------------
+NUXT_PUBLIC_APP_BASE_URL="http://localhost:3000"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,24 @@ For more information, see https://agents.md/
 
 This document provides instructions for AI agents to work with the Klankern project. Please follow these guidelines to ensure smooth collaboration.
 
+## Code Style Guidelines
+
+- **NEVER** commit or push to Git without explicit approval.
+- File names and custom elements/components use Kebab-case. DO: `utility-file.ts`, `<my-component />`. DON'T: `utility_file.ts`, `<MyComponent />`.
+- Avoid [Nuxt Auto-Imports](https://nuxt.com/docs/4.x/guide/concepts/auto-imports)! Prefer consistent path aliasing (create as needed). Use `import xy from "#imports";` as a fallback to document dependency on auto-import in file. Try to refactor auto-imports if you encounter them.
+
 ## AI Agent Collaboration
 
 - **Agent-Relevant Files**: Keep all files relevant for AI agents within the `./vibes/` directory.
 - **Knowledge Graph**: If the MCP server `memory` is available, proactively and autonomously read the graph at the beginning of each session and keep it updated and maintained as you go.
+- **NEVER** assume! **ALWAYS** ask clarifying questions.
+
+## Known AI issues in the project
+
+- Agents have no idea how to write proper Vitest tests in a Nuxt v4 environment. They screw up, get stuck in a loop and completely ignore documentation even if presented on a silver platter.
+- Agents are completely lost with the current ESLint setup and how to fix linting errors, especially regarding imports and types.
+
+## Further reading
+
+- [`README.md`](./README.md)
+- [Initial project plan](./vibes/PROJECT.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,38 @@ The database seed script creates the following default users:
 - **Email:** `user@example.com`
 - **Password:** `password123`
 
+## Testing Guidelines & Learnings for AI Agents
+
+This section documents specific challenges and solutions encountered during testing in the Klankern project environment.
+
+### General Testing Principles
+
+- Always prefer explicit environment setup for tests (e.g., `// @vitest-environment nuxt`).
+- Be aware of the context in which a script runs (Node.js vs. Nuxt server) for path alias resolution.
+
+### Nuxt Test Environment Specifics
+
+- **Nuxt Path Aliases in Non-Nuxt Contexts:**
+    - Problem: Server-side scripts (like `seed.ts`) and Vitest unit tests (in `test/unit/`) do not resolve Nuxt path aliases (`#server`, `~`, `~~`).
+    - Solution: Use relative paths (`../`) in these contexts.
+- **Drizzle Schema Inspection:**
+    - Problem: Low-level inspection of Drizzle schema constraints (e.g., via `getTableConfig`) is unreliable or undocumented for testing.
+    - Solution: Focus on testing the existence of table/column objects and the higher-level Drizzle `relations` objects.
+
+### End-to-End (E2E) Testing with @nuxt/test-utils
+
+- **Environment Setup:**
+    - Ensure `playwright-core` is installed (`pnpm add -D playwright-core`).
+    - Install Playwright browser binaries: `pnpm exec playwright install` (or `pnpm exec playwright-core install`).
+    - Explicitly set the test environment in the file: `// @vitest-environment nuxt`.
+    - Use `await setup({ browser: true, dev: true });` in the `describe` block to enable browser testing and hot-reloading.
+- **Authentication:**
+    - Use a test-only API endpoint (`POST /api/__test__/login`) to programmatically log in users. This endpoint must be guarded by `process.env.NODE_ENV === 'test'`.
+    - Use `$fetch` for API calls within E2E tests, as it correctly resolves the test server's base URL. Avoid `page.request.post` for relative URLs.
+- **Known Issue: Nuxt Test Server File Discovery:**
+    - Problem: The `@nuxt/test-utils` test server does not reliably discover new API route files created _during_ a test session, even with `dev: true`.
+    - Status: Unresolved. This issue currently blocks the E2E test from functioning.
+
 ## AI Agent Collaboration
 
 - **Agent-Relevant Files**: Keep all files relevant for AI agents within the `./vibes/` directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This document provides instructions for AI agents to work with the Klankern proj
 - **NEVER** commit or push to Git without explicit approval.
 - File names and custom elements/components use Kebab-case. DO: `utility-file.ts`, `<my-component />`. DON'T: `utility_file.ts`, `<MyComponent />`.
 - Avoid [Nuxt Auto-Imports](https://nuxt.com/docs/4.x/guide/concepts/auto-imports)! Prefer consistent path aliasing (create as needed). Use `import xy from "#imports";` as a fallback to document dependency on auto-import in file. Try to refactor auto-imports if you encounter them.
+- Schemas and types should be shared and reused across the project via files in `./shared/types`.
 
 ## AI Agent Collaboration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,23 @@ This document provides instructions for AI agents to work with the Klankern proj
 - Schemas and types should be shared and reused across the project via files in `./shared/types`.
 - **Separation of concerns**: Do not mix presentation with business logic. Example: API calls should be handled by a Pinia store, not by a component. Use composables.
 
+## Test Users & Credentials
+
+The database seed script creates the following default users:
+
+**1. Admin User**
+
+- **Username:** `admin`
+- **Email:** `admin@example.com`
+- **Password:** `password123`
+
+**2. Standard Test User (for E2E tests)**
+
+- **ID:** `a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11`
+- **Username:** `testuser`
+- **Email:** `user@example.com`
+- **Password:** `password123`
+
 ## AI Agent Collaboration
 
 - **Agent-Relevant Files**: Keep all files relevant for AI agents within the `./vibes/` directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This document provides instructions for AI agents to work with the Klankern proj
 - File names and custom elements/components use Kebab-case. DO: `utility-file.ts`, `<my-component />`. DON'T: `utility_file.ts`, `<MyComponent />`.
 - Avoid [Nuxt Auto-Imports](https://nuxt.com/docs/4.x/guide/concepts/auto-imports)! Prefer consistent path aliasing (create as needed). Use `import xy from "#imports";` as a fallback to document dependency on auto-import in file. Try to refactor auto-imports if you encounter them.
 - Schemas and types should be shared and reused across the project via files in `./shared/types`.
+- **Separation of concerns**: Do not mix presentation with business logic. Example: API calls should be handled by a Pinia store, not by a component. Use composables.
 
 ## AI Agent Collaboration
 

--- a/README.md
+++ b/README.md
@@ -106,12 +106,23 @@ Maintain code quality and consistency with:
 ## 📜 Version Control
 
 - **Commit Messages:** Please adhere to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages. This helps with automated changelog generation and understanding project history.
+- **Branches**:
+    - **NEVER** push to `main` directly! It is the production branch. Only PRs from `develop` are allowed to go into `main`.
+    - All development happens in `develop`.
+    - If a task is more complex or might introduce breaking changes, it will be handled in a separate branch derived from `develop`. Naming convention: `type/brief-task-description`. Examples: `feature/add-pwa-functionality`, `bugfix/repair-broken-event-bus`. A PR to merge into `develop` is required.
 
 ## 🔑 Default Admin Login
 
 For local development and testing, you can use the following credentials:
 
-- **Email:** `test@example.com`
+- **Email:** `admin@example.com`
+- **Password:** `password123`
+
+## 🔑 Default Test User Login
+
+For E2E testing and general user-level feature development, you can use the following credentials:
+
+- **Email:** `user@example.com`
 - **Password:** `password123`
 
 ## ✍️ Coding Guidelines
@@ -134,10 +145,7 @@ To ensure a consistent, maintainable, and high-quality codebase, please follow t
 ### Project-Specific Nuxt Guidelines
 
 - **Server-Side Logging:** Always use the `Winston` logger for server-side logging. Direct `console.log` usage is prohibited on the server.
-- **Client-Side Logging:** `console.log` is permitted _only_ within the `useLogger` composable for client-side logging.
-- **Nuxt Auto-Imports:**
-    - **NEVER** explicitly import from `~/shared/types`. These types are globally available.
-    - For other auto-imported items (e.g., composables), **ALWAYS** use the `#imports` virtual alias if explicit import is needed (e.g., `import { useUserSession } from '#imports';`).
+- **Client-Side Logging:** Always use the `useLogger` composable for client-side logging. Direct `console.log` usage is prohibited in the frontend.
 - **Authentication:** We use `nuxt-security` and `nuxt-auth-utils`. Server-side utilities like `setUserSession` are auto-imported in the `server/` directory. Login/logout logic is handled by the `useAuth` composable.
 
 ---

--- a/app/pages/families/[id].vue
+++ b/app/pages/families/[id].vue
@@ -1,0 +1,86 @@
+<script lang="ts" setup>
+import { onMounted } from "vue";
+import { useRoute } from "vue-router";
+import { storeToRefs } from "pinia";
+import { useFamilyStore } from "~/stores/families";
+
+// Define component-specific metadata
+definePageMeta({
+    middleware: ["auth"], // Ensure only authenticated users can access this page
+});
+
+const route = useRoute();
+const familyStore = useFamilyStore();
+
+// Get reactive state and getters from the store
+const { isLoading, error, familyName, members, isManager } =
+    storeToRefs(familyStore);
+
+const familyId = Array.isArray(route.params.id)
+    ? route.params.id[0]
+    : route.params.id;
+
+// Fetch the family data when the component is mounted
+onMounted(() => {
+    if (familyId) {
+        familyStore.fetchFamily(familyId);
+    }
+});
+
+function handleInvite() {
+    // TODO: Implement invite member modal or navigation
+    alert("Invite member functionality to be implemented.");
+}
+</script>
+
+<template>
+    <div>
+        <div v-if="isLoading">
+            <p>Loading family details...</p>
+        </div>
+
+        <div v-else-if="error">
+            <p class="error-message">Error: {{ error }}</p>
+            <nuxt-link to="/families">Go back to your families</nuxt-link>
+        </div>
+
+        <div v-else-if="familyStore.currentFamily">
+            <header>
+                <h1>{{ familyName }}</h1>
+                <div v-if="isManager" class="actions">
+                    <button-base @click="handleInvite"
+                        >Invite Member</button-base
+                    >
+                </div>
+            </header>
+
+            <section id="members">
+                <h2>Members</h2>
+                <!-- 
+                    Placeholder for the FamilyMembersList component.
+                    This will be created in the next step.
+                -->
+                <ul>
+                    <li v-for="member in members" :key="member.userId">
+                        {{ member.displayName || member.username }} ({{
+                            member.role
+                        }})
+                    </li>
+                </ul>
+            </section>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.error-message {
+    color: red;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+</style>

--- a/app/pages/families/[id].vue
+++ b/app/pages/families/[id].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { onMounted } from "vue";
+import { onMounted, ref } from "vue";
 import { useRoute } from "vue-router";
 import { storeToRefs } from "pinia";
 import { useFamilyStore } from "~/stores/families";
@@ -13,12 +13,16 @@ const route = useRoute();
 const familyStore = useFamilyStore();
 
 // Get reactive state and getters from the store
-const { isLoading, error, familyName, members, isManager } =
+const { isLoading, error, familyName, members, isManager, isSendingInvite } =
     storeToRefs(familyStore);
 
 const familyId = Array.isArray(route.params.id)
     ? route.params.id[0]
     : route.params.id;
+
+const showInviteForm = ref(false);
+const inviteeEmail = ref("");
+const invitationSent = ref(false);
 
 // Fetch the family data when the component is mounted
 onMounted(() => {
@@ -27,9 +31,21 @@ onMounted(() => {
     }
 });
 
-function handleInvite() {
-    // TODO: Implement invite member modal or navigation
-    alert("Invite member functionality to be implemented.");
+async function handleSendInvitation() {
+    if (!familyId || !inviteeEmail.value) return;
+
+    const success = await familyStore.sendInvitation(
+        familyId,
+        inviteeEmail.value,
+    );
+
+    if (success) {
+        invitationSent.value = true;
+        inviteeEmail.value = "";
+        showInviteForm.value = false;
+        // Optionally hide the success message after a few seconds
+        setTimeout(() => (invitationSent.value = false), 5000);
+    }
 }
 </script>
 
@@ -39,7 +55,7 @@ function handleInvite() {
             <p>Loading family details...</p>
         </div>
 
-        <div v-else-if="error">
+        <div v-else-if="error && !invitationSent">
             <p class="error-message">Error: {{ error }}</p>
             <nuxt-link to="/families">Go back to your families</nuxt-link>
         </div>
@@ -48,11 +64,40 @@ function handleInvite() {
             <header>
                 <h1>{{ familyName }}</h1>
                 <div v-if="isManager" class="actions">
-                    <button-base @click="handleInvite"
-                        >Invite Member</button-base
-                    >
+                    <button-base @click="showInviteForm = !showInviteForm">
+                        {{ showInviteForm ? "Cancel" : "Invite Member" }}
+                    </button-base>
                 </div>
             </header>
+
+            <div v-if="invitationSent" class="success-message">
+                <p>Invitation sent successfully!</p>
+            </div>
+
+            <form
+                v-if="isManager && showInviteForm"
+                class="invite-form"
+                @submit.prevent="handleSendInvitation"
+            >
+                <h3>Invite a New Member</h3>
+                <div>
+                    <label for="inviteeEmail">Email Address</label>
+                    <input
+                        id="inviteeEmail"
+                        v-model="inviteeEmail"
+                        type="email"
+                        placeholder="e.g., new.member@example.com"
+                        :disabled="isSendingInvite"
+                        required
+                    />
+                </div>
+                <button-base type="submit" :disabled="isSendingInvite">
+                    {{ isSendingInvite ? "Sending..." : "Send Invitation" }}
+                </button-base>
+                <div v-if="error" class="error-message">
+                    <p>{{ error }}</p>
+                </div>
+            </form>
 
             <section id="members">
                 <h2>Members</h2>
@@ -76,11 +121,25 @@ function handleInvite() {
 .error-message {
     color: red;
 }
-
+.success-message {
+    color: green;
+    border: 1px solid green;
+    padding: 1rem;
+    margin-bottom: 1rem;
+}
 header {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 2rem;
+}
+.invite-form {
+    margin-bottom: 2rem;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+.invite-form div {
+    margin-bottom: 1rem;
 }
 </style>

--- a/app/pages/families/create.vue
+++ b/app/pages/families/create.vue
@@ -1,0 +1,67 @@
+<script lang="ts" setup>
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { useFamilyStore } from "~/stores/families";
+import { storeToRefs } from "pinia";
+
+// Define component-specific metadata
+definePageMeta({
+    middleware: ["auth"], // Ensure only authenticated users can access this page
+});
+
+const router = useRouter();
+const familyStore = useFamilyStore();
+
+// Use storeToRefs to keep reactivity on state and getters
+const { isCreating, error } = storeToRefs(familyStore);
+
+const familyName = ref("");
+
+async function handleCreateFamily() {
+    if (!familyName.value.trim()) {
+        familyStore.error = "Family name cannot be empty.";
+        return;
+    }
+
+    const newFamily = await familyStore.createFamily(familyName.value);
+
+    if (newFamily && newFamily.id) {
+        // Redirect to the new family's dashboard page
+        await router.push(`/families/${newFamily.id}`);
+    }
+}
+</script>
+
+<template>
+    <div>
+        <h1>Create a New Family</h1>
+        <form @submit.prevent="handleCreateFamily">
+            <div>
+                <label for="familyName">Family Name</label>
+                <input
+                    id="familyName"
+                    v-model="familyName"
+                    type="text"
+                    placeholder="e.g., The Cool Family"
+                    :disabled="isCreating"
+                    required
+                />
+            </div>
+
+            <button-base type="submit" :disabled="isCreating">
+                {{ isCreating ? "Creating..." : "Create Family" }}
+            </button-base>
+
+            <div v-if="error" class="error-message">
+                <p>Error: {{ error }}</p>
+            </div>
+        </form>
+    </div>
+</template>
+
+<style scoped>
+.error-message {
+    color: red;
+    margin-top: 1rem;
+}
+</style>

--- a/app/pages/user/invitations/index.vue
+++ b/app/pages/user/invitations/index.vue
@@ -1,0 +1,116 @@
+<script lang="ts" setup>
+import { onMounted, ref } from "vue";
+import { storeToRefs } from "pinia";
+import { useInvitationStore } from "~/stores/invitations";
+
+// Define component-specific metadata
+definePageMeta({
+    middleware: ["auth"], // Ensure only authenticated users can access this page
+});
+
+const store = useInvitationStore();
+const { pendingInvitations, isLoading, error } = storeToRefs(store);
+
+// To track which specific invitation is being processed
+const processingToken = ref<string | null>(null);
+
+onMounted(() => {
+    store.fetchPendingInvitations();
+});
+
+async function handleAccept(token: string) {
+    processingToken.value = token;
+    await store.acceptInvitation(token);
+    processingToken.value = null;
+    // The store action already removes the item from the list, so the UI will update automatically.
+}
+
+async function handleDecline(token: string) {
+    processingToken.value = token;
+    await store.declineInvitation(token);
+    processingToken.value = null;
+}
+</script>
+
+<template>
+    <div>
+        <h1>Your Invitations</h1>
+
+        <div v-if="isLoading">
+            <p>Loading invitations...</p>
+        </div>
+
+        <div v-else-if="error">
+            <p class="error-message">Error: {{ error }}</p>
+        </div>
+
+        <div v-else-if="pendingInvitations.length === 0">
+            <p>You have no pending invitations.</p>
+        </div>
+
+        <ul v-else class="invitation-list">
+            <li
+                v-for="invitation in pendingInvitations"
+                :key="invitation.token"
+                class="invitation-card"
+            >
+                <p>
+                    You have been invited to join the
+                    <strong>{{ invitation.family.name }}</strong> family by
+                    <strong>{{
+                        invitation.invitedByUser.display_name ||
+                        invitation.invitedByUser.username
+                    }}</strong
+                    >.
+                </p>
+                <div class="actions">
+                    <button-base
+                        :disabled="processingToken === invitation.token"
+                        @click="handleAccept(invitation.token)"
+                    >
+                        {{
+                            processingToken === invitation.token
+                                ? "Processing..."
+                                : "Accept"
+                        }}
+                    </button-base>
+                    <button-base
+                        variant="secondary"
+                        :disabled="processingToken === invitation.token"
+                        @click="handleDecline(invitation.token)"
+                    >
+                        Decline
+                    </button-base>
+                </div>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<style scoped>
+.error-message {
+    color: red;
+}
+
+.invitation-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.invitation-card {
+    border: 1px solid #ccc;
+    padding: 1rem;
+    border-radius: 4px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.actions {
+    display: flex;
+    gap: 0.5rem;
+}
+</style>

--- a/app/stores/families.ts
+++ b/app/stores/families.ts
@@ -1,0 +1,107 @@
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import { useAuth } from "~/composables/useAuth";
+
+// Define interfaces for our state shape for type safety
+interface FamilyMember {
+    userId: string;
+    displayName: string | null;
+    username: string;
+    role: string;
+}
+
+interface FamilyDetails {
+    id: string;
+    name: string;
+    members: FamilyMember[];
+}
+
+function isH3Error(error: unknown): error is { data: { message: string } } {
+    return typeof error === "object" && error !== null && "data" in error;
+}
+
+export const useFamilyStore = defineStore("family", () => {
+    // State
+    const currentFamily = ref<FamilyDetails | null>(null);
+    const isLoading = ref(false); // For fetching
+    const isCreating = ref(false); // For creating
+    const error = ref<string | null>(null);
+
+    // Getters (as computed properties)
+    const members = computed(() => currentFamily.value?.members || []);
+    const familyName = computed(() => currentFamily.value?.name || "");
+
+    // Get the current authenticated user from the auth composable
+    const { user: authUser } = useAuth();
+
+    const currentUserMembership = computed(() => {
+        if (!authUser.value || !currentFamily.value) return null;
+        return members.value.find(
+            (member) => member.userId === authUser.value?.id,
+        );
+    });
+
+    const isManager = computed(() => {
+        return currentUserMembership.value?.role === "manager";
+    });
+
+    // Actions
+    async function fetchFamily(familyId: string) {
+        isLoading.value = true;
+        error.value = null;
+        currentFamily.value = null; // Reset on new fetch
+
+        try {
+            const data = await $fetch<FamilyDetails>(
+                `/api/families/${familyId}`,
+            );
+            currentFamily.value = data;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value =
+                    "An unexpected error occurred while fetching family details.";
+            }
+        } finally {
+            isLoading.value = false;
+        }
+    }
+
+    async function createFamily(name: string) {
+        isCreating.value = true;
+        error.value = null;
+        try {
+            const newFamily = await $fetch<FamilyDetails>("/api/families", {
+                method: "POST",
+                body: { name },
+            });
+            return newFamily;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value =
+                    "An unexpected error occurred while creating the family.";
+            }
+            return null;
+        } finally {
+            isCreating.value = false;
+        }
+    }
+
+    return {
+        // State
+        currentFamily,
+        isLoading,
+        isCreating,
+        error,
+        // Getters
+        members,
+        familyName,
+        isManager,
+        // Actions
+        fetchFamily,
+        createFamily,
+    };
+});

--- a/app/stores/families.ts
+++ b/app/stores/families.ts
@@ -25,6 +25,7 @@ export const useFamilyStore = defineStore("family", () => {
     const currentFamily = ref<FamilyDetails | null>(null);
     const isLoading = ref(false); // For fetching
     const isCreating = ref(false); // For creating
+    const isSendingInvite = ref(false);
     const error = ref<string | null>(null);
 
     // Getters (as computed properties)
@@ -90,11 +91,36 @@ export const useFamilyStore = defineStore("family", () => {
         }
     }
 
+    async function sendInvitation(familyId: string, email: string) {
+        isSendingInvite.value = true;
+        error.value = null;
+        try {
+            await $fetch(`/api/families/${familyId}/invitations`, {
+                method: "POST",
+                body: { email },
+            });
+            // Optionally, refetch family data to show pending invitations
+            // await fetchFamily(familyId);
+            return true;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value =
+                    "An unexpected error occurred while sending the invitation.";
+            }
+            return false;
+        } finally {
+            isSendingInvite.value = false;
+        }
+    }
+
     return {
         // State
         currentFamily,
         isLoading,
         isCreating,
+        isSendingInvite,
         error,
         // Getters
         members,
@@ -103,5 +129,6 @@ export const useFamilyStore = defineStore("family", () => {
         // Actions
         fetchFamily,
         createFamily,
+        sendInvitation,
     };
 });

--- a/app/stores/invitations.ts
+++ b/app/stores/invitations.ts
@@ -1,0 +1,93 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+// Define an interface for the invitation object for type safety
+interface PendingInvitation {
+    id: string;
+    token: string;
+    family: {
+        name: string;
+    };
+    invitedByUser: {
+        display_name: string | null;
+        username: string;
+    };
+    created_at: string; // Assuming it comes as an ISO string
+}
+
+function isH3Error(error: unknown): error is { data: { message: string } } {
+    return typeof error === "object" && error !== null && "data" in error;
+}
+
+export const useInvitationStore = defineStore("invitation", () => {
+    // State
+    const pendingInvitations = ref<PendingInvitation[]>([]);
+    const isLoading = ref(false);
+    const error = ref<string | null>(null);
+
+    // Actions
+    async function fetchPendingInvitations() {
+        isLoading.value = true;
+        error.value = null;
+        try {
+            const data = await $fetch<PendingInvitation[]>("/api/invitations");
+            pendingInvitations.value = data;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value =
+                    "An unexpected error occurred while fetching invitations.";
+            }
+        }
+    }
+
+    async function acceptInvitation(token: string): Promise<boolean> {
+        try {
+            await $fetch(`/api/invitations/${token}/accept`, {
+                method: "POST",
+            });
+            // On success, remove the invitation from the local state
+            pendingInvitations.value = pendingInvitations.value.filter(
+                (inv) => inv.token !== token,
+            );
+            return true;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value = "Failed to accept the invitation.";
+            }
+            return false;
+        }
+    }
+
+    async function declineInvitation(token: string): Promise<boolean> {
+        try {
+            await $fetch(`/api/invitations/${token}/decline`, {
+                method: "POST",
+            });
+            // On success, remove the invitation from the local state
+            pendingInvitations.value = pendingInvitations.value.filter(
+                (inv) => inv.token !== token,
+            );
+            return true;
+        } catch (e: unknown) {
+            if (isH3Error(e)) {
+                error.value = e.data.message;
+            } else {
+                error.value = "Failed to decline the invitation.";
+            }
+            return false;
+        }
+    }
+
+    return {
+        pendingInvitations,
+        isLoading,
+        error,
+        fetchPendingInvitations,
+        acceptInvitation,
+        declineInvitation,
+    };
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     },
     "dependencies": {
         "@pinia/nuxt": "0.11.2",
+        "@types/nodemailer": "7.0.2",
+        "nodemailer": "7.0.9",
         "nuxt": "^4.1.2",
         "nuxt-auth-utils": "0.5.25",
         "nuxt-security": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "happy-dom": "^18.0.1",
         "lefthook": "1.13.4",
         "pg": "8.16.3",
+        "playwright-core": "1.56.0",
         "prettier": "^3.6.2",
         "prettier-plugin-vue": "^1.1.6",
         "tsx": "4.20.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 1.9.0(@typescript-eslint/utils@8.46.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(@vue/compiler-sfc@3.5.22)(eslint-import-resolver-node@0.3.9)(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       '@nuxt/test-utils':
         specifier: 3.19.2
-        version: 3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+        version: 3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(playwright-core@1.56.0)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       '@types/pg':
         specifier: 8.15.5
         version: 8.15.5
@@ -102,6 +102,9 @@ importers:
       pg:
         specifier: 8.16.3
         version: 8.16.3
+      playwright-core:
+        specifier: 1.56.0
+        version: 1.56.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -4445,6 +4448,11 @@ packages:
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
+  playwright-core@1.56.0:
+    resolution: {integrity: sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
@@ -6908,7 +6916,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/test-utils@3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
+  '@nuxt/test-utils@3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(playwright-core@1.56.0)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
       '@nuxt/kit': 3.19.2(magicast@0.3.5)
       c12: 3.3.0(magicast@0.3.5)
@@ -6932,11 +6940,12 @@ snapshots:
       tinyexec: 1.0.1
       ufo: 1.6.1
       unplugin: 2.3.10
-      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      vitest-environment-nuxt: 1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(playwright-core@1.56.0)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
       vue: 3.5.22(typescript@5.9.2)
     optionalDependencies:
       '@vue/test-utils': 2.4.6
       happy-dom: 18.0.1
+      playwright-core: 1.56.0
       vitest: 3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
     transitivePeerDependencies:
       - magicast
@@ -10783,6 +10792,8 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
+  playwright-core@1.56.0: {}
+
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
@@ -11883,9 +11894,9 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
+  vitest-environment-nuxt@1.0.1(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(playwright-core@1.56.0)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)):
     dependencies:
-      '@nuxt/test-utils': 3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      '@nuxt/test-utils': 3.19.2(@vue/test-utils@2.4.6)(happy-dom@18.0.1)(magicast@0.3.5)(playwright-core@1.56.0)(typescript@5.9.2)(vitest@3.2.4(@types/node@24.6.0)(happy-dom@18.0.1)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@pinia/nuxt':
         specifier: 0.11.2
         version: 0.11.2(magicast@0.3.5)(pinia@3.0.3(typescript@5.9.2)(vue@3.5.22(typescript@5.9.2)))
+      '@types/nodemailer':
+        specifier: 7.0.2
+        version: 7.0.2
+      nodemailer:
+        specifier: 7.0.9
+        version: 7.0.9
       nuxt:
         specifier: ^4.1.2
         version: 4.1.2(@parcel/watcher@2.5.1)(@types/node@24.6.0)(@vue/compiler-sfc@3.5.22)(db0@0.3.2(drizzle-orm@0.44.5(@types/pg@8.15.5)(pg@8.16.3)))(drizzle-orm@0.44.5(@types/pg@8.15.5)(pg@8.16.3))(eslint@9.36.0(jiti@2.6.0))(ioredis@5.8.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.3)(terser@5.44.0)(tsx@4.20.6)(typescript@5.9.2)(vite@7.1.7(@types/node@24.6.0)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))(yaml@2.8.1)
@@ -140,6 +146,131 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       '@types/json-schema': ^7.0.15
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-sesv2@3.901.0':
+    resolution: {integrity: sha512-xCS2qZlvgbXKZbJW8XgU8OEAL7BJyVqJ5yODOQxa1TJFZ/+wEhik9XZtULjNnQqa29sJDpPltuSDG1aDG2OUxQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-sso@3.901.0':
+    resolution: {integrity: sha512-sGyDjjkJ7ppaE+bAKL/Q5IvVCxtoyBIzN+7+hWTS/mUxWJ9EOq9238IqmVIIK6sYNIzEf9yhobfMARasPYVTNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/core@3.901.0':
+    resolution: {integrity: sha512-brKAc3y64tdhyuEf+OPIUln86bRTqkLgb9xkd6kUdIeA5+qmp/N6amItQz+RN4k4O3kqkCPYnAd3LonTKluobw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.901.0':
+    resolution: {integrity: sha512-5hAdVl3tBuARh3zX5MLJ1P/d+Kr5kXtDU3xm1pxUEF4xt2XkEEpwiX5fbkNkz2rbh3BCt2gOHsAbh6b3M7n+DA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.901.0':
+    resolution: {integrity: sha512-Ggr7+0M6QZEsrqRkK7iyJLf4LkIAacAxHz9c4dm9hnDdU7vqrlJm6g73IxMJXWN1bIV7IxfpzB11DsRrB/oNjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.901.0':
+    resolution: {integrity: sha512-zxadcDS0hNJgv8n4hFYJNOXyfjaNE1vvqIiF/JzZSQpSSYXzCd+WxXef5bQh+W3giDtRUmkvP5JLbamEFjZKyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.901.0':
+    resolution: {integrity: sha512-dPuFzMF7L1s/lQyT3wDxqLe82PyTH+5o1jdfseTEln64LJMl0ZMWaKX/C1UFNDxaTd35Cgt1bDbjjAWHMiKSFQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.901.0':
+    resolution: {integrity: sha512-/IWgmgM3Cl1wTdJA5HqKMAojxLkYchh5kDuphApxKhupLu6Pu0JBOHU8A5GGeFvOycyaVwosod6zDduINZxe+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.901.0':
+    resolution: {integrity: sha512-SjmqZQHmqFSET7+6xcZgtH7yEyh5q53LN87GqwYlJZ6KJ5oNw11acUNEhUOL1xTSJEvaWqwTIkS2zqrzLcM9bw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.901.0':
+    resolution: {integrity: sha512-NYjy/6NLxH9m01+pfpB4ql8QgAorJcu8tw69kzHwUd/ql6wUDTbC7HcXqtKlIwWjzjgj2BKL7j6SyFapgCuafA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.901.0':
+    resolution: {integrity: sha512-yWX7GvRmqBtbNnUW7qbre3GvZmyYwU0WHefpZzDTYDoNgatuYq6LgUIQ+z5C04/kCRoFkAFrHag8a3BXqFzq5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-logger@3.901.0':
+    resolution: {integrity: sha512-UoHebjE7el/tfRo8/CQTj91oNUm+5Heus5/a4ECdmWaSCHCS/hXTsU3PTTHAY67oAQR8wBLFPfp3mMvXjB+L2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.901.0':
+    resolution: {integrity: sha512-Wd2t8qa/4OL0v/oDpCHHYkgsXJr8/ttCxrvCKAt0H1zZe2LlRhY9gpDVKqdertfHrHDj786fOvEQA28G1L75Dg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.901.0':
+    resolution: {integrity: sha512-prgjVC3fDT2VIlmQPiw/cLee8r4frTam9GILRUVQyDdNtshNwV3MiaSCLzzQJjKJlLgnBLNUHJCSmvUVtg+3iA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.901.0':
+    resolution: {integrity: sha512-Zby4F03fvD9xAgXGPywyk4bC1jCbnyubMEYChLYohD+x20ULQCf+AimF/Btn7YL+hBpzh1+RmqmvZcx+RgwgNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/nested-clients@3.901.0':
+    resolution: {integrity: sha512-feAAAMsVwctk2Tms40ONybvpfJPLCmSdI+G+OTrNpizkGLNl6ik2Ng2RzxY6UqOfN8abqKP/DOUj1qYDRDG8ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.901.0':
+    resolution: {integrity: sha512-7F0N888qVLHo4CSQOsnkZ4QAp8uHLKJ4v3u09Ly5k4AEStrSlFpckTPyUx6elwGL+fxGjNE2aakK8vEgzzCV0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.901.0':
+    resolution: {integrity: sha512-2IWxbll/pRucp1WQkHi2W5E2SVPGBvk4Is923H7gpNksbVFws18ItjMM8ZpGm44cJEoy1zR5gjhLFklatpuoOw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/token-providers@3.901.0':
+    resolution: {integrity: sha512-pJEr1Ggbc/uVTDqp9IbNu9hdr0eQf3yZix3s4Nnyvmg4xmJSGAlbPC9LrNr5u3CDZoc8Z9CuLrvbP4MwYquNpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/types@3.901.0':
+    resolution: {integrity: sha512-FfEM25hLEs4LoXsLXQ/q6X6L4JmKkKkbVFpKD4mwfVHtRVQG6QxJiCPcrkcPISquiy6esbwK2eh64TWbiD60cg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.893.0':
+    resolution: {integrity: sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-endpoints@3.901.0':
+    resolution: {integrity: sha512-5nZP3hGA8FHEtKvEQf4Aww5QZOkjLW1Z+NixSd+0XKfHvA39Ah5sZboScjLx0C9kti/K3OGW1RCx5K9Zc3bZqg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-locate-window@3.893.0':
+    resolution: {integrity: sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.901.0':
+    resolution: {integrity: sha512-Ntb6V/WFI21Ed4PDgL/8NSfoZQQf9xzrwNgiwvnxgAl/KvAvRBgQtqj5gHsDX8Nj2YmJuVoHfH9BGjL9VQ4WNg==}
+
+  '@aws-sdk/util-user-agent-node@3.901.0':
+    resolution: {integrity: sha512-l59KQP5TY7vPVUfEURc7P5BJKuNg1RSsAKBQW7LHLECXjLqDUbo2SMLrexLBEoArSt6E8QOrIN0C8z/0Xk0jYw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.901.0':
+    resolution: {integrity: sha512-pxFCkuAP7Q94wMTNPAwi6hEtNrp/BdFf+HOrIEeFQsk4EoOmpKY3I6S+u6A9Wg295J80Kh74LqDWM22ux3z6Aw==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.0.1':
+    resolution: {integrity: sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1451,6 +1582,178 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@smithy/abort-controller@4.2.0':
+    resolution: {integrity: sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.3.0':
+    resolution: {integrity: sha512-9oH+n8AVNiLPK/iK/agOsoWfrKZ3FGP3502tkksd6SRsKMYiu7AFX0YXo6YBADdsAj7C+G/aLKdsafIJHxuCkQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.14.0':
+    resolution: {integrity: sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.0':
+    resolution: {integrity: sha512-SOhFVvFH4D5HJZytb0bLKxCrSnwcqPiNlrw+S4ZXjMnsC+o9JcUQzbZOEQcA8yv9wJFNhfsUiIUKiEnYL68Big==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.0':
+    resolution: {integrity: sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.0':
+    resolution: {integrity: sha512-ugv93gOhZGysTctZh9qdgng8B+xO0cj+zN0qAZ+Sgh7qTQGPOJbMdIuyP89KNfUyfAqFSNh5tMvC+h2uCpmTtA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.0':
+    resolution: {integrity: sha512-ZmK5X5fUPAbtvRcUPtk28aqIClVhbfcmfoS4M7UQBTnDdrNxhsrxYVv0ZEl5NaPSyExsPWqL4GsPlRvtlwg+2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.0':
+    resolution: {integrity: sha512-6ZAnwrXFecrA4kIDOcz6aLBhU5ih2is2NdcZtobBDSdSHtE9a+MThB5uqyK4XXesdOCvOcbCm2IGB95birTSOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.3.0':
+    resolution: {integrity: sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.0':
+    resolution: {integrity: sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.0':
+    resolution: {integrity: sha512-rpTQ7D65/EAbC6VydXlxjvbifTf4IH+sADKg6JmAvhkflJO2NvDeyU9qsWUNBelJiQFcXKejUHWRSdmpJmEmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.0':
+    resolution: {integrity: sha512-G5CJ//eqRd9OARrQu9MK1H8fNm2sMtqFh6j8/rPozhEL+Dokpvi1Og+aCixTuwDAGZUkJPk6hJT5jchbk/WCyg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.0':
+    resolution: {integrity: sha512-5QgHNuWdT9j9GwMPPJCKxy2KDxZ3E5l4M3/5TatSZrqYVoEiqQrDfAq8I6KWZw7RZOHtVtCzEPdYz7rHZixwcA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.3.0':
+    resolution: {integrity: sha512-RHZ/uWCmSNZ8cneoWEVsVwMZBKy/8123hEpm57vgGXA3Irf/Ja4v9TVshHK2ML5/IqzAZn0WhINHOP9xl+Qy6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.0':
+    resolution: {integrity: sha512-rV6wFre0BU6n/tx2Ztn5LdvEdNZ2FasQbPQmDOPfV9QQyDmsCkOAB0osQjotRCQg+nSKFmINhyda0D3AnjSBJw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.0':
+    resolution: {integrity: sha512-6POSYlmDnsLKb7r1D3SVm7RaYW6H1vcNcTWGWrF7s9+2noNYvUsm7E4tz5ZQ9HXPmKn6Hb67pBDRIjrT4w/d7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.0':
+    resolution: {integrity: sha512-Q4oFD0ZmI8yJkiPPeGUITZj++4HHYCW3pYBYfIobUCkYpI6mbkzmG1MAQQ3lJYYWj3iNqfzOenUZu+jqdPQ16A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.0':
+    resolution: {integrity: sha512-BjATSNNyvVbQxOOlKse0b0pSezTWGMvA87SvoFoFlkRsKXVsN3bEtjCxvsNXJXfnAzlWFPaT9DmhWy1vn0sNEA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.0':
+    resolution: {integrity: sha512-Ylv1ttUeKatpR0wEOMnHf1hXMktPUMObDClSWl2TpCVT4DwtJhCeighLzSLbgH3jr5pBNM0LDXT5yYxUvZ9WpA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.3.0':
+    resolution: {integrity: sha512-VCUPPtNs+rKWlqqntX0CbVvWyjhmX30JCtzO+s5dlzzxrvSfRh5SY0yxnkirvc1c80vdKQttahL71a9EsdolSQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.0':
+    resolution: {integrity: sha512-MKNyhXEs99xAZaFhm88h+3/V+tCRDQ+PrDzRqL0xdDpq4gjxcMmf5rBA3YXgqZqMZ/XwemZEurCBQMfxZOWq/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.7.0':
+    resolution: {integrity: sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.6.0':
+    resolution: {integrity: sha512-4lI9C8NzRPOv66FaY1LL1O/0v0aLVrq/mXP/keUa9mJOApEeae43LsLd2kZRUJw91gxOQfLIrV3OvqPgWz1YsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.0':
+    resolution: {integrity: sha512-AlBmD6Idav2ugmoAL6UtR6ItS7jU5h5RNqLMZC7QrLCoITA9NzIN3nx9GWi8g4z1pfWh2r9r96SX/jHiNwPJ9A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.2.0':
+    resolution: {integrity: sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.0':
+    resolution: {integrity: sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.2.0':
+    resolution: {integrity: sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.0':
+    resolution: {integrity: sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.0':
+    resolution: {integrity: sha512-TXeCn22D56vvWr/5xPqALc9oO+LN+QpFjrSM7peG/ckqEPoI3zaKZFp+bFwfmiHhn5MGWPaLCqDOJPPIixk9Wg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.0':
+    resolution: {integrity: sha512-u9OOfDa43MjagtJZ8AapJcmimP+K2Z7szXn8xbty4aza+7P1wjFmy2ewjSbhEiYQoW1unTlOAIV165weYAaowA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.0':
+    resolution: {integrity: sha512-BWSiuGbwRnEE2SFfaAZEX0TqaxtvtSYPM/J73PFVm+A29Fg1HTPiYFb8TmX1DXp4hgcdyJcNQmprfd5foeORsg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.4.0':
+    resolution: {integrity: sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
@@ -1486,6 +1789,9 @@ packages:
 
   '@types/node@24.6.0':
     resolution: {integrity: sha512-F1CBxgqwOMc4GKJ7eY22hWhBVQuMYTtqI8L0FcszYcpYX0fzfDGpez22Xau8Mgm7O9fI+zA/TYIdq3tGWfweBA==}
+
+  '@types/nodemailer@7.0.2':
+    resolution: {integrity: sha512-Zo6uOA9157WRgBk/ZhMpTQ/iCWLMk7OIs/Q9jvHarMvrzUUP/MDdPHL2U1zpf57HrrWGv4nYQn5uIxna0xY3xw==}
 
   '@types/parse-path@7.1.0':
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
@@ -2071,6 +2377,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.12.1:
+    resolution: {integrity: sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -2985,6 +3294,10 @@ packages:
   fast-npm-meta@0.4.7:
     resolution: {integrity: sha512-aZU3i3eRcSb2NCq8i6N6IlyiTyF6vqAqzBGl2NBF6ngNx/GIqfYbkLDIKZ4z4P0o/RmtsFnVqHwdrSm13o4tnQ==}
 
+  fast-xml-parser@5.2.5:
+    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -3823,6 +4136,10 @@ packages:
 
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
+
+  nodemailer@7.0.9:
+    resolution: {integrity: sha512-9/Qm0qXIByEP8lEV2qOqcAW7bRpL8CR9jcTwk3NBnHJNmP9fIJ86g2fgmIXqHY+nj55ZEMwWqYAT2QTDpRUYiQ==}
+    engines: {node: '>=6.0.0'}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -4744,6 +5061,9 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strnum@2.1.1:
+    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
+
   structured-clone-es@1.0.0:
     resolution: {integrity: sha512-FL8EeKFFyNQv5cMnXI31CIMCsFarSVI2bF0U0ImeNE3g/F1IvJQyqzOXxPBRXiwQfyBTlbNe88jh1jFW0O/jiQ==}
 
@@ -5395,6 +5715,391 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.0
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-locate-window': 3.893.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.901.0
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-sesv2@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/credential-provider-node': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/signature-v4-multi-region': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/xml-builder': 3.901.0
+      '@smithy/core': 3.14.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-stream': 4.4.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/credential-provider-env': 3.901.0
+      '@aws-sdk/credential-provider-http': 3.901.0
+      '@aws-sdk/credential-provider-process': 3.901.0
+      '@aws-sdk/credential-provider-sso': 3.901.0
+      '@aws-sdk/credential-provider-web-identity': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.901.0':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.901.0
+      '@aws-sdk/credential-provider-http': 3.901.0
+      '@aws-sdk/credential-provider-ini': 3.901.0
+      '@aws-sdk/credential-provider-process': 3.901.0
+      '@aws-sdk/credential-provider-sso': 3.901.0
+      '@aws-sdk/credential-provider-web-identity': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.901.0':
+    dependencies:
+      '@aws-sdk/client-sso': 3.901.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/token-providers': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@aws/lambda-invoke-store': 0.0.1
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-arn-parser': 3.893.0
+      '@smithy/core': 3.14.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-stream': 4.4.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@smithy/core': 3.14.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.901.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/middleware-host-header': 3.901.0
+      '@aws-sdk/middleware-logger': 3.901.0
+      '@aws-sdk/middleware-recursion-detection': 3.901.0
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/region-config-resolver': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@aws-sdk/util-endpoints': 3.901.0
+      '@aws-sdk/util-user-agent-browser': 3.901.0
+      '@aws-sdk/util-user-agent-node': 3.901.0
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/core': 3.14.0
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/hash-node': 4.2.0
+      '@smithy/invalid-dependency': 4.2.0
+      '@smithy/middleware-content-length': 4.2.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-retry': 4.4.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.0
+      '@smithy/util-defaults-mode-browser': 4.2.0
+      '@smithy/util-defaults-mode-node': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.901.0':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/signature-v4': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.901.0':
+    dependencies:
+      '@aws-sdk/core': 3.901.0
+      '@aws-sdk/nested-clients': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.901.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.893.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-endpoints': 3.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.893.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.901.0':
+    dependencies:
+      '@aws-sdk/types': 3.901.0
+      '@smithy/types': 4.6.0
+      bowser: 2.12.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.901.0':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.901.0
+      '@aws-sdk/types': 3.901.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.901.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      fast-xml-parser: 5.2.5
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.0.1': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6693,6 +7398,280 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@smithy/abort-controller@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.3.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/core@3.14.0':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-stream': 4.4.0
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/querystring-builder': 4.2.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.3.0':
+    dependencies:
+      '@smithy/core': 3.14.0
+      '@smithy/middleware-serde': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/url-parser': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/service-error-classification': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-retry': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.0':
+    dependencies:
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.0':
+    dependencies:
+      '@smithy/property-provider': 4.2.0
+      '@smithy/shared-ini-file-loader': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.3.0':
+    dependencies:
+      '@smithy/abort-controller': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/querystring-builder': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+
+  '@smithy/shared-ini-file-loader@4.3.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.0
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.7.0':
+    dependencies:
+      '@smithy/core': 3.14.0
+      '@smithy/middleware-endpoint': 4.3.0
+      '@smithy/middleware-stack': 4.2.0
+      '@smithy/protocol-http': 5.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-stream': 4.4.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.6.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.0':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.2.0':
+    dependencies:
+      '@smithy/property-provider': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      bowser: 2.12.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.0':
+    dependencies:
+      '@smithy/config-resolver': 4.3.0
+      '@smithy/credential-provider-imds': 4.2.0
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/property-provider': 4.2.0
+      '@smithy/smithy-client': 4.7.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.0':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.0':
+    dependencies:
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.0':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.0
+      '@smithy/types': 4.6.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.4.0':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.0
+      '@smithy/node-http-handler': 4.3.0
+      '@smithy/types': 4.6.0
+      '@smithy/util-base64': 4.2.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@speed-highlight/core@1.2.7': {}
 
   '@stylistic/eslint-plugin@5.4.0(eslint@9.36.0(jiti@2.6.0))':
@@ -6731,6 +7710,13 @@ snapshots:
   '@types/node@24.6.0':
     dependencies:
       undici-types: 7.13.0
+
+  '@types/nodemailer@7.0.2':
+    dependencies:
+      '@aws-sdk/client-sesv2': 3.901.0
+      '@types/node': 24.6.0
+    transitivePeerDependencies:
+      - aws-crt
 
   '@types/parse-path@7.1.0':
     dependencies:
@@ -7459,6 +8445,8 @@ snapshots:
   birpc@2.6.1: {}
 
   boolbase@1.0.0: {}
+
+  bowser@2.12.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -8427,6 +9415,10 @@ snapshots:
 
   fast-npm-meta@0.4.7: {}
 
+  fast-xml-parser@5.2.5:
+    dependencies:
+      strnum: 2.1.1
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -9310,6 +10302,8 @@ snapshots:
   node-mock-http@1.0.3: {}
 
   node-releases@2.0.21: {}
+
+  nodemailer@7.0.9: {}
 
   nopt@7.2.1:
     dependencies:
@@ -10428,6 +11422,8 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strnum@2.1.1: {}
+
   structured-clone-es@1.0.0: {}
 
   stylehacks@7.0.6(postcss@8.5.6):
@@ -10539,8 +11535,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.20.6:
     dependencies:

--- a/server/api/__test__/login.post.ts
+++ b/server/api/__test__/login.post.ts
@@ -1,0 +1,75 @@
+import { eq } from "drizzle-orm";
+import { defineEventHandler, createError, readBody } from "h3";
+import { setUserSession } from "#imports";
+import { db } from "#server/db";
+import { users } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    // CRITICAL: This endpoint is for testing purposes only and must never be exposed
+    // in a production environment.
+    if (process.env.NODE_ENV !== "test") {
+        logger.warn(
+            "Attempted access to test-only login endpoint in non-test environment.",
+        );
+        throw createError({
+            statusCode: 404,
+            statusMessage: "Not Found",
+        });
+    }
+
+    try {
+        const { userId } = await readBody(event);
+        if (!userId) {
+            throw createError({
+                statusCode: 400,
+                statusMessage: "A userId must be provided.",
+            });
+        }
+
+        // Find the user and their roles to create a valid session object
+        const userToLogin = await db.query.users.findFirst({
+            where: eq(users.id, userId),
+            with: {
+                userRoles: {
+                    with: {
+                        role: true,
+                    },
+                },
+            },
+        });
+
+        if (!userToLogin) {
+            throw createError({
+                statusCode: 404,
+                statusMessage: "User not found.",
+            });
+        }
+
+        // Construct the session object that the application expects
+        const sessionUser = {
+            id: userToLogin.id,
+            username: userToLogin.username,
+            display_name: userToLogin.display_name,
+            email: userToLogin.email,
+            roles: userToLogin.userRoles.map((ur) => ur.role),
+        };
+
+        await setUserSession(event, sessionUser);
+
+        return { message: `User ${userId} logged in successfully.` };
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+        logger.error("Error in test login endpoint:", error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/[familyId]/invitations/index.post.ts
+++ b/server/api/families/[familyId]/invitations/index.post.ts
@@ -1,0 +1,111 @@
+import { and, eq } from "drizzle-orm";
+import {
+    defineEventHandler,
+    createError,
+    readValidatedBody,
+    getRouterParams,
+} from "h3";
+import { randomUUID } from "node:crypto";
+import { db } from "#server/db";
+import { familyInvitations, familyMembers, users } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+import { sendInvitationEmail } from "#server/utils/email-sender";
+import { InvitationCreateSchema } from "~/shared/types/invitation";
+
+export default defineEventHandler(async (event) => {
+    const { familyId } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    const parseResult = await readValidatedBody(event, (body) =>
+        InvitationCreateSchema.safeParse(body),
+    );
+
+    if (!parseResult.success) {
+        throw createError({ statusCode: 400, data: parseResult.error.errors });
+    }
+
+    const { email: invitedEmail } = parseResult.data;
+
+    try {
+        // 1. Authorize: Check if the current user is a manager of the family.
+        const membership = await db.query.familyMembers.findFirst({
+            where: and(
+                eq(familyMembers.family_id, familyId),
+                eq(familyMembers.user_id, user.id),
+            ),
+            with: {
+                family: { columns: { name: true } },
+            },
+        });
+
+        if (membership?.role !== "manager") {
+            throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+        }
+
+        // 2. Conflict Check: See if a user with this email is already in the family.
+        const existingMember = await db.query.users.findFirst({
+            where: eq(users.email, invitedEmail),
+            with: {
+                familyMembers: {
+                    where: eq(familyMembers.family_id, familyId),
+                },
+            },
+        });
+
+        if (existingMember && existingMember.familyMembers.length > 0) {
+            throw createError({
+                statusCode: 409,
+                statusMessage: "User is already a member of this family.",
+            });
+        }
+
+        // 3. Create Invitation
+        const token = randomUUID();
+        const expiresAt = new Date();
+        expiresAt.setDate(expiresAt.getDate() + 7); // Invitation expires in 7 days
+
+        await db.insert(familyInvitations).values({
+            family_id: familyId,
+            invited_by_user_id: user.id,
+            invited_email: invitedEmail,
+            token,
+            expires_at: expiresAt,
+        });
+
+        // 4. Send Email
+        await sendInvitationEmail({
+            to: invitedEmail,
+            token,
+            familyName: membership.family.name,
+            inviterName: user.display_name || user.username,
+        });
+
+        event.node.res.statusCode = 201;
+        return { message: "Invitation sent successfully." };
+    } catch (error) {
+        // Handle known conflict errors from our own createError calls
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            const potentialError = error as { statusCode: unknown };
+            if (potentialError.statusCode === 409) {
+                throw error;
+            }
+        }
+
+        logger.error(
+            `Error sending invitation for family ${familyId} by user ${user.id}:`,
+            error,
+        );
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/[familyId]/invitations/index.post.ts
+++ b/server/api/families/[familyId]/invitations/index.post.ts
@@ -10,7 +10,7 @@ import { db } from "#server/db";
 import { familyInvitations, familyMembers, users } from "#server/db/schema";
 import { logger } from "#server/utils/logger";
 import { sendInvitationEmail } from "#server/utils/email-sender";
-import { InvitationCreateSchema } from "~/shared/types/invitation";
+import { InvitationCreateSchema } from "~~/shared/types/invitation";
 
 export default defineEventHandler(async (event) => {
     const { familyId } = await getRouterParams(event);

--- a/server/api/families/[familyId]/members/[userId].delete.ts
+++ b/server/api/families/[familyId]/members/[userId].delete.ts
@@ -1,0 +1,84 @@
+import { and, eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { familyMembers } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { familyId, userId: userIdToRemove } = await getRouterParams(event);
+    const managerUser = event.context.user;
+
+    if (!managerUser) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    // 1. Business Rule: Prevent a manager from removing themselves.
+    if (managerUser.id === userIdToRemove) {
+        throw createError({
+            statusCode: 400,
+            statusMessage:
+                "A manager cannot remove themselves from the family.",
+        });
+    }
+
+    try {
+        // 2. Authorize: Check if the current user is a manager of this family.
+        const managerMembership = await db.query.familyMembers.findFirst({
+            where: and(
+                eq(familyMembers.family_id, familyId),
+                eq(familyMembers.user_id, managerUser.id),
+            ),
+        });
+
+        if (managerMembership?.role !== "manager") {
+            throw createError({
+                statusCode: 403,
+                statusMessage:
+                    "Forbidden: Only a family manager can remove members.",
+            });
+        }
+
+        // 3. Perform Deletion
+        const [deletedMembership] = await db
+            .delete(familyMembers)
+            .where(
+                and(
+                    eq(familyMembers.family_id, familyId),
+                    eq(familyMembers.user_id, userIdToRemove),
+                ),
+            )
+            .returning();
+
+        // 4. Verify that a member was actually removed.
+        if (!deletedMembership) {
+            throw createError({
+                statusCode: 404,
+                statusMessage: "Member not found in this family.",
+            });
+        }
+
+        logger.info(
+            `User ${userIdToRemove} removed from family ${familyId} by manager ${managerUser.id}`,
+        );
+
+        event.node.res.statusCode = 204; // No Content
+        return;
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(
+            `Error removing user ${userIdToRemove} from family ${familyId}:`,
+            error,
+        );
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/[familyId]/members/index.get.ts
+++ b/server/api/families/[familyId]/members/index.get.ts
@@ -1,0 +1,72 @@
+import { and, eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { familyMembers } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { familyId } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    try {
+        // 1. Authorize: Ensure the current user is a member of the family they are trying to view.
+        const currentUserMembership = await db.query.familyMembers.findFirst({
+            where: and(
+                eq(familyMembers.family_id, familyId),
+                eq(familyMembers.user_id, user.id),
+            ),
+        });
+
+        if (!currentUserMembership) {
+            throw createError({
+                statusCode: 403,
+                statusMessage:
+                    "Forbidden: You are not a member of this family.",
+            });
+        }
+
+        // 2. Fetch all members of the family and their user details.
+        const memberships = await db.query.familyMembers.findMany({
+            where: eq(familyMembers.family_id, familyId),
+            with: {
+                user: {
+                    columns: {
+                        id: true,
+                        username: true,
+                        display_name: true,
+                        email: true,
+                    },
+                },
+            },
+        });
+
+        // 3. Format the response to be a clean list of members.
+        const memberList = memberships.map((m) => ({
+            userId: m.user.id,
+            username: m.user.username,
+            displayName: m.user.display_name,
+            email: m.user.email,
+            role: m.role,
+        }));
+
+        return memberList;
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(`Error fetching members for family ${familyId}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/[id].delete.ts
+++ b/server/api/families/[id].delete.ts
@@ -1,0 +1,57 @@
+import { and, eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { families, familyMembers } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { id: familyId } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    try {
+        // 1. Authorize: Check if the current user is a manager of this family.
+        const membership = await db.query.familyMembers.findFirst({
+            where: and(
+                eq(familyMembers.family_id, familyId),
+                eq(familyMembers.user_id, user.id),
+            ),
+        });
+
+        if (membership?.role !== "manager") {
+            throw createError({
+                statusCode: 403,
+                statusMessage:
+                    "Forbidden: Only a family manager can delete the family.",
+            });
+        }
+
+        // 2. Perform the soft delete by setting the deleted_at timestamp.
+        await db
+            .update(families)
+            .set({ deleted_at: new Date() })
+            .where(eq(families.id, familyId));
+
+        logger.info(`Family ${familyId} soft-deleted by manager ${user.id}`);
+
+        event.node.res.statusCode = 204; // No Content
+        return;
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(`Error soft-deleting family ${familyId}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/[id].get.ts
+++ b/server/api/families/[id].get.ts
@@ -1,0 +1,78 @@
+import { eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { families } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { id: familyId } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    try {
+        // 1. Fetch the family and all its members in a single query.
+        const familyData = await db.query.families.findFirst({
+            where: eq(families.id, familyId),
+            with: {
+                members: {
+                    with: {
+                        user: {
+                            columns: {
+                                id: true,
+                                username: true,
+                                display_name: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        if (!familyData) {
+            throw createError({
+                statusCode: 404,
+                statusMessage: "Family not found",
+            });
+        }
+
+        // 2. Authorize: Check if the current user is in the list of members.
+        const isCurrentUserMember = familyData.members.some(
+            (member) => member.user_id === user.id,
+        );
+
+        if (!isCurrentUserMember) {
+            throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+        }
+
+        // 3. Format the response.
+        const response = {
+            id: familyData.id,
+            name: familyData.name,
+            members: familyData.members.map((m) => ({
+                userId: m.user.id,
+                username: m.user.username,
+                displayName: m.user.display_name,
+                role: m.role,
+            })),
+        };
+
+        return response;
+    } catch (error) {
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(`Error fetching details for family ${familyId}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/index.get.ts
+++ b/server/api/families/index.get.ts
@@ -27,10 +27,10 @@ export default defineEventHandler(async (event) => {
             },
         });
 
-        // Extract the family object from each membership record
-        const families = userFamilyMemberships.map(
-            (membership) => membership.family,
-        );
+        // Extract the family object from each membership record and filter out soft-deleted families
+        const families = userFamilyMemberships
+            .map((membership) => membership.family)
+            .filter((family) => family && !family.deleted_at);
 
         return families;
     } catch (error) {

--- a/server/api/families/index.get.ts
+++ b/server/api/families/index.get.ts
@@ -1,0 +1,43 @@
+import { defineEventHandler, createError } from "h3";
+import { db } from "#server/db";
+import { familyMembers } from "#server/db/schema";
+import { eq } from "drizzle-orm";
+import { logger } from "#server/utils/logger";
+
+/**
+ * @api {get} /api/families
+ * @description Fetches all families the authenticated user is a member of.
+ * @returns {Promise<object[]>} An array of family objects.
+ */
+export default defineEventHandler(async (event) => {
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({
+            statusCode: 401,
+            statusMessage: "Unauthorized",
+        });
+    }
+
+    try {
+        const userFamilyMemberships = await db.query.familyMembers.findMany({
+            where: eq(familyMembers.user_id, user.id),
+            with: {
+                family: true, // Include the full family object
+            },
+        });
+
+        // Extract the family object from each membership record
+        const families = userFamilyMemberships.map(
+            (membership) => membership.family,
+        );
+
+        return families;
+    } catch (error) {
+        logger.error(`Error fetching families for user ${user.id}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "Internal Server Error",
+        });
+    }
+});

--- a/server/api/families/index.post.ts
+++ b/server/api/families/index.post.ts
@@ -1,0 +1,67 @@
+import { defineEventHandler, createError, readValidatedBody } from "h3";
+import { db } from "#server/db";
+import { families, familyMembers } from "#server/db/schema";
+import { FamilyCreateSchema } from "~/shared/types/family";
+import { logger } from "#server/utils/logger";
+
+/**
+ * @api {post} /api/families
+ * @description Creates a new family and assigns the creator as the manager.
+ * @param {object} event - The H3 event object.
+ * @returns {Promise<object>} The newly created family object.
+ */
+export default defineEventHandler(async (event) => {
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({
+            statusCode: 401,
+            statusMessage: "Unauthorized",
+        });
+    }
+
+    const parseResult = await readValidatedBody(event, (body) =>
+        FamilyCreateSchema.safeParse(body),
+    );
+
+    if (!parseResult.success) {
+        throw createError({
+            statusCode: 400,
+            statusMessage: "Validation failed",
+            data: parseResult.error.errors,
+        });
+    }
+
+    const { name } = parseResult.data;
+
+    try {
+        const newFamily = await db.transaction(async (tx) => {
+            // Step 1: Create the new family record
+            const [insertedFamily] = await tx
+                .insert(families)
+                .values({ name, creator_id: user.id })
+                .returning();
+
+            if (!insertedFamily) {
+                throw new Error("Family creation failed during insert.");
+            }
+
+            // Step 2: Add the creator as the first member with the 'manager' role
+            await tx.insert(familyMembers).values({
+                family_id: insertedFamily.id,
+                user_id: user.id,
+                role: "manager",
+            });
+
+            return insertedFamily;
+        });
+
+        return newFamily;
+    } catch (error) {
+        logger.error(`Error creating family for user ${user.id}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/families/index.post.ts
+++ b/server/api/families/index.post.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler, createError, readValidatedBody } from "h3";
 import { db } from "#server/db";
 import { families, familyMembers } from "#server/db/schema";
-import { FamilyCreateSchema } from "~/shared/types/family";
+import { FamilyCreateSchema } from "~~/shared/types/family";
 import { logger } from "#server/utils/logger";
 
 /**

--- a/server/api/invitations/[invitationToken]/accept.post.ts
+++ b/server/api/invitations/[invitationToken]/accept.post.ts
@@ -1,0 +1,91 @@
+import { eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { familyInvitations, familyMembers } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { invitationToken } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    if (!invitationToken) {
+        throw createError({ statusCode: 400, statusMessage: "Invalid token" });
+    }
+
+    try {
+        // 1. Find the invitation
+        const invitation = await db.query.familyInvitations.findFirst({
+            where: eq(familyInvitations.token, invitationToken),
+        });
+
+        if (!invitation) {
+            throw createError({
+                statusCode: 404,
+                statusMessage: "Invitation not found",
+            });
+        }
+
+        // 2. Validate the invitation
+        if (invitation.status !== "pending") {
+            throw createError({
+                statusCode: 400,
+                statusMessage: `Invitation has already been ${invitation.status}.`,
+            });
+        }
+
+        if (new Date() > invitation.expires_at) {
+            throw createError({
+                statusCode: 400,
+                statusMessage: "Invitation has expired.",
+            });
+        }
+
+        if (invitation.invited_email !== user.email) {
+            throw createError({
+                statusCode: 403,
+                statusMessage: "This invitation is for a different user.",
+            });
+        }
+
+        // 3. Perform actions in a transaction
+        await db.transaction(async (tx) => {
+            // Add user to the family
+            await tx.insert(familyMembers).values({
+                family_id: invitation.family_id,
+                user_id: user.id,
+                role: "member",
+            });
+
+            // Update the invitation status
+            await tx
+                .update(familyInvitations)
+                .set({ status: "accepted" })
+                .where(eq(familyInvitations.id, invitation.id));
+        });
+
+        logger.info(
+            `User ${user.id} accepted invitation ${invitation.id} for family ${invitation.family_id}`,
+        );
+
+        return { message: "Invitation accepted successfully." };
+    } catch (error) {
+        // Type guard for H3 errors to re-throw them
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(`Error accepting invitation ${invitationToken}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/invitations/[invitationToken]/decline.post.ts
+++ b/server/api/invitations/[invitationToken]/decline.post.ts
@@ -1,0 +1,81 @@
+import { eq } from "drizzle-orm";
+import { defineEventHandler, createError, getRouterParams } from "h3";
+import { db } from "#server/db";
+import { familyInvitations } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const { invitationToken } = await getRouterParams(event);
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    if (!invitationToken) {
+        throw createError({ statusCode: 400, statusMessage: "Invalid token" });
+    }
+
+    try {
+        // 1. Find the invitation
+        const invitation = await db.query.familyInvitations.findFirst({
+            where: eq(familyInvitations.token, invitationToken),
+        });
+
+        if (!invitation) {
+            throw createError({
+                statusCode: 404,
+                statusMessage: "Invitation not found",
+            });
+        }
+
+        // 2. Validate the invitation
+        if (invitation.status !== "pending") {
+            throw createError({
+                statusCode: 400,
+                statusMessage: `Invitation has already been ${invitation.status}.`,
+            });
+        }
+
+        if (new Date() > invitation.expires_at) {
+            throw createError({
+                statusCode: 400,
+                statusMessage: "Invitation has expired.",
+            });
+        }
+
+        if (invitation.invited_email !== user.email) {
+            throw createError({
+                statusCode: 403,
+                statusMessage: "This invitation is for a different user.",
+            });
+        }
+
+        // 3. Update the invitation status
+        await db
+            .update(familyInvitations)
+            .set({ status: "declined" })
+            .where(eq(familyInvitations.id, invitation.id));
+
+        logger.info(
+            `User ${user.id} declined invitation ${invitation.id} for family ${invitation.family_id}`,
+        );
+
+        return { message: "Invitation declined successfully." };
+    } catch (error) {
+        // Type guard for H3 errors to re-throw them
+        if (
+            typeof error === "object" &&
+            error !== null &&
+            "statusCode" in error
+        ) {
+            throw error;
+        }
+
+        logger.error(`Error declining invitation ${invitationToken}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/api/invitations/index.get.ts
+++ b/server/api/invitations/index.get.ts
@@ -1,0 +1,45 @@
+import { and, eq } from "drizzle-orm";
+import { defineEventHandler, createError } from "h3";
+import { db } from "#server/db";
+import { familyInvitations } from "#server/db/schema";
+import { logger } from "#server/utils/logger";
+
+export default defineEventHandler(async (event) => {
+    const user = event.context.user;
+
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+
+    try {
+        const pendingInvitations = await db.query.familyInvitations.findMany({
+            where: and(
+                eq(familyInvitations.invited_email, user.email),
+                eq(familyInvitations.status, "pending"),
+            ),
+            // Include related family and inviter names for display on the frontend
+            with: {
+                family: {
+                    columns: {
+                        name: true,
+                    },
+                },
+                invitedByUser: {
+                    columns: {
+                        display_name: true,
+                        username: true,
+                    },
+                },
+            },
+            orderBy: (invitations, { desc }) => [desc(invitations.created_at)],
+        });
+
+        return pendingInvitations;
+    } catch (error) {
+        logger.error(`Error fetching invitations for user ${user.id}:`, error);
+        throw createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+});

--- a/server/db/migrations/0002_elite_firebird.sql
+++ b/server/db/migrations/0002_elite_firebird.sql
@@ -1,0 +1,34 @@
+CREATE TABLE "families" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"name" text NOT NULL,
+	"creator_id" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"deleted_at" timestamp
+);
+--> statement-breakpoint
+CREATE TABLE "family_invitations" (
+	"id" uuid PRIMARY KEY DEFAULT uuidv7() NOT NULL,
+	"family_id" uuid NOT NULL,
+	"invited_by_user_id" uuid NOT NULL,
+	"invited_email" text NOT NULL,
+	"token" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "family_invitations_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "family_members" (
+	"family_id" uuid NOT NULL,
+	"user_id" uuid NOT NULL,
+	"role" text NOT NULL,
+	CONSTRAINT "family_members_family_id_user_id_pk" PRIMARY KEY("family_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "families" ADD CONSTRAINT "families_creator_id_users_id_fk" FOREIGN KEY ("creator_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "family_invitations" ADD CONSTRAINT "family_invitations_family_id_families_id_fk" FOREIGN KEY ("family_id") REFERENCES "public"."families"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "family_invitations" ADD CONSTRAINT "family_invitations_invited_by_user_id_users_id_fk" FOREIGN KEY ("invited_by_user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "family_members" ADD CONSTRAINT "family_members_family_id_families_id_fk" FOREIGN KEY ("family_id") REFERENCES "public"."families"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "family_members" ADD CONSTRAINT "family_members_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/db/migrations/0003_amused_jack_flag.sql
+++ b/server/db/migrations/0003_amused_jack_flag.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "corkboard_posts" ADD COLUMN "family_id" uuid;--> statement-breakpoint
+ALTER TABLE "corkboard_posts" ADD CONSTRAINT "corkboard_posts_family_id_families_id_fk" FOREIGN KEY ("family_id") REFERENCES "public"."families"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "corkboard_posts_family_id_idx" ON "corkboard_posts" USING btree ("family_id");--> statement-breakpoint
+CREATE INDEX "families_creator_id_idx" ON "families" USING btree ("creator_id");--> statement-breakpoint
+CREATE INDEX "families_deleted_at_idx" ON "families" USING btree ("deleted_at");--> statement-breakpoint
+CREATE INDEX "family_invitations_family_id_idx" ON "family_invitations" USING btree ("family_id");--> statement-breakpoint
+CREATE INDEX "family_invitations_invited_email_idx" ON "family_invitations" USING btree ("invited_email");--> statement-breakpoint
+CREATE INDEX "family_members_user_id_idx" ON "family_members" USING btree ("user_id");

--- a/server/db/migrations/meta/0002_snapshot.json
+++ b/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,727 @@
+{
+    "id": "a84519be-b1d8-400e-9b8e-5e6e8860017c",
+    "prevId": "4819aba3-047e-4069-9da5-001514ac9395",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.corkboard_posts": {
+            "name": "corkboard_posts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "type": {
+                    "name": "type",
+                    "type": "corkboard_post_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "corkboard_posts_user_id_idx": {
+                    "name": "corkboard_posts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "corkboard_posts_type_idx": {
+                    "name": "corkboard_posts_type_idx",
+                    "columns": [
+                        {
+                            "expression": "type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "corkboard_posts_created_at_idx": {
+                    "name": "corkboard_posts_created_at_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "corkboard_posts_user_id_users_id_fk": {
+                    "name": "corkboard_posts_user_id_users_id_fk",
+                    "tableFrom": "corkboard_posts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.families": {
+            "name": "families",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "creator_id": {
+                    "name": "creator_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "families_creator_id_users_id_fk": {
+                    "name": "families_creator_id_users_id_fk",
+                    "tableFrom": "families",
+                    "tableTo": "users",
+                    "columnsFrom": ["creator_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.family_invitations": {
+            "name": "family_invitations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "family_id": {
+                    "name": "family_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invited_by_user_id": {
+                    "name": "invited_by_user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invited_email": {
+                    "name": "invited_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "family_invitations_family_id_families_id_fk": {
+                    "name": "family_invitations_family_id_families_id_fk",
+                    "tableFrom": "family_invitations",
+                    "tableTo": "families",
+                    "columnsFrom": ["family_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "family_invitations_invited_by_user_id_users_id_fk": {
+                    "name": "family_invitations_invited_by_user_id_users_id_fk",
+                    "tableFrom": "family_invitations",
+                    "tableTo": "users",
+                    "columnsFrom": ["invited_by_user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "family_invitations_token_unique": {
+                    "name": "family_invitations_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.family_members": {
+            "name": "family_members",
+            "schema": "",
+            "columns": {
+                "family_id": {
+                    "name": "family_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "family_members_family_id_families_id_fk": {
+                    "name": "family_members_family_id_families_id_fk",
+                    "tableFrom": "family_members",
+                    "tableTo": "families",
+                    "columnsFrom": ["family_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "family_members_user_id_users_id_fk": {
+                    "name": "family_members_user_id_users_id_fk",
+                    "tableFrom": "family_members",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "family_members_family_id_user_id_pk": {
+                    "name": "family_members_family_id_user_id_pk",
+                    "columns": ["family_id", "user_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.roles": {
+            "name": "roles",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "roles_name_unique": {
+                    "name": "roles_name_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["name"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_token_idx": {
+                    "name": "sessions_token_idx",
+                    "columns": [
+                        {
+                            "expression": "token",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "sessions_token_unique": {
+                    "name": "sessions_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_roles": {
+            "name": "user_roles",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role_id": {
+                    "name": "role_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "user_roles_user_id_idx": {
+                    "name": "user_roles_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_roles_role_id_idx": {
+                    "name": "user_roles_role_id_idx",
+                    "columns": [
+                        {
+                            "expression": "role_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_roles_user_id_users_id_fk": {
+                    "name": "user_roles_user_id_users_id_fk",
+                    "tableFrom": "user_roles",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "user_roles_role_id_roles_id_fk": {
+                    "name": "user_roles_role_id_roles_id_fk",
+                    "tableFrom": "user_roles",
+                    "tableTo": "roles",
+                    "columnsFrom": ["role_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "user_roles_user_id_role_id_pk": {
+                    "name": "user_roles_user_id_role_id_pk",
+                    "columns": ["user_id", "role_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "username": {
+                    "name": "username",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "display_name": {
+                    "name": "display_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": true
+                },
+                "dashboard_config": {
+                    "name": "dashboard_config",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "users_email_idx": {
+                    "name": "users_email_idx",
+                    "columns": [
+                        {
+                            "expression": "email",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_username_idx": {
+                    "name": "users_username_idx",
+                    "columns": [
+                        {
+                            "expression": "username",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_is_active_idx": {
+                    "name": "users_is_active_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_created_at_idx": {
+                    "name": "users_created_at_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                },
+                "users_username_unique": {
+                    "name": "users_username_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["username"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.corkboard_post_type": {
+            "name": "corkboard_post_type",
+            "schema": "public",
+            "values": ["note", "photo"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/server/db/migrations/meta/0003_snapshot.json
+++ b/server/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,835 @@
+{
+    "id": "52c4d981-2198-47d3-a92c-cedaaef75ea5",
+    "prevId": "a84519be-b1d8-400e-9b8e-5e6e8860017c",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.corkboard_posts": {
+            "name": "corkboard_posts",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "family_id": {
+                    "name": "family_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "type": {
+                    "name": "type",
+                    "type": "corkboard_post_type",
+                    "typeSchema": "public",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "data": {
+                    "name": "data",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "corkboard_posts_user_id_idx": {
+                    "name": "corkboard_posts_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "corkboard_posts_family_id_idx": {
+                    "name": "corkboard_posts_family_id_idx",
+                    "columns": [
+                        {
+                            "expression": "family_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "corkboard_posts_type_idx": {
+                    "name": "corkboard_posts_type_idx",
+                    "columns": [
+                        {
+                            "expression": "type",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "corkboard_posts_created_at_idx": {
+                    "name": "corkboard_posts_created_at_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "corkboard_posts_user_id_users_id_fk": {
+                    "name": "corkboard_posts_user_id_users_id_fk",
+                    "tableFrom": "corkboard_posts",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "corkboard_posts_family_id_families_id_fk": {
+                    "name": "corkboard_posts_family_id_families_id_fk",
+                    "tableFrom": "corkboard_posts",
+                    "tableTo": "families",
+                    "columnsFrom": ["family_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "set null",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.families": {
+            "name": "families",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "creator_id": {
+                    "name": "creator_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "families_creator_id_idx": {
+                    "name": "families_creator_id_idx",
+                    "columns": [
+                        {
+                            "expression": "creator_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "families_deleted_at_idx": {
+                    "name": "families_deleted_at_idx",
+                    "columns": [
+                        {
+                            "expression": "deleted_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "families_creator_id_users_id_fk": {
+                    "name": "families_creator_id_users_id_fk",
+                    "tableFrom": "families",
+                    "tableTo": "users",
+                    "columnsFrom": ["creator_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.family_invitations": {
+            "name": "family_invitations",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "family_id": {
+                    "name": "family_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invited_by_user_id": {
+                    "name": "invited_by_user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "invited_email": {
+                    "name": "invited_email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "status": {
+                    "name": "status",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "'pending'"
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "family_invitations_family_id_idx": {
+                    "name": "family_invitations_family_id_idx",
+                    "columns": [
+                        {
+                            "expression": "family_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "family_invitations_invited_email_idx": {
+                    "name": "family_invitations_invited_email_idx",
+                    "columns": [
+                        {
+                            "expression": "invited_email",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "family_invitations_family_id_families_id_fk": {
+                    "name": "family_invitations_family_id_families_id_fk",
+                    "tableFrom": "family_invitations",
+                    "tableTo": "families",
+                    "columnsFrom": ["family_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "family_invitations_invited_by_user_id_users_id_fk": {
+                    "name": "family_invitations_invited_by_user_id_users_id_fk",
+                    "tableFrom": "family_invitations",
+                    "tableTo": "users",
+                    "columnsFrom": ["invited_by_user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "family_invitations_token_unique": {
+                    "name": "family_invitations_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.family_members": {
+            "name": "family_members",
+            "schema": "",
+            "columns": {
+                "family_id": {
+                    "name": "family_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role": {
+                    "name": "role",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "family_members_user_id_idx": {
+                    "name": "family_members_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "family_members_family_id_families_id_fk": {
+                    "name": "family_members_family_id_families_id_fk",
+                    "tableFrom": "family_members",
+                    "tableTo": "families",
+                    "columnsFrom": ["family_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "family_members_user_id_users_id_fk": {
+                    "name": "family_members_user_id_users_id_fk",
+                    "tableFrom": "family_members",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "family_members_family_id_user_id_pk": {
+                    "name": "family_members_family_id_user_id_pk",
+                    "columns": ["family_id", "user_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.roles": {
+            "name": "roles",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "description": {
+                    "name": "description",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "roles_name_unique": {
+                    "name": "roles_name_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["name"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.sessions": {
+            "name": "sessions",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "sessions_user_id_idx": {
+                    "name": "sessions_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_token_idx": {
+                    "name": "sessions_token_idx",
+                    "columns": [
+                        {
+                            "expression": "token",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "sessions_expires_at_idx": {
+                    "name": "sessions_expires_at_idx",
+                    "columns": [
+                        {
+                            "expression": "expires_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "sessions_user_id_users_id_fk": {
+                    "name": "sessions_user_id_users_id_fk",
+                    "tableFrom": "sessions",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "sessions_token_unique": {
+                    "name": "sessions_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user_roles": {
+            "name": "user_roles",
+            "schema": "",
+            "columns": {
+                "user_id": {
+                    "name": "user_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "role_id": {
+                    "name": "role_id",
+                    "type": "uuid",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {
+                "user_roles_user_id_idx": {
+                    "name": "user_roles_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "user_roles_role_id_idx": {
+                    "name": "user_roles_role_id_idx",
+                    "columns": [
+                        {
+                            "expression": "role_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "user_roles_user_id_users_id_fk": {
+                    "name": "user_roles_user_id_users_id_fk",
+                    "tableFrom": "user_roles",
+                    "tableTo": "users",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                },
+                "user_roles_role_id_roles_id_fk": {
+                    "name": "user_roles_role_id_roles_id_fk",
+                    "tableFrom": "user_roles",
+                    "tableTo": "roles",
+                    "columnsFrom": ["role_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {
+                "user_roles_user_id_role_id_pk": {
+                    "name": "user_roles_user_id_role_id_pk",
+                    "columns": ["user_id", "role_id"]
+                }
+            },
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.users": {
+            "name": "users",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "uuid",
+                    "primaryKey": true,
+                    "notNull": true,
+                    "default": "uuidv7()"
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "username": {
+                    "name": "username",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "display_name": {
+                    "name": "display_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "first_name": {
+                    "name": "first_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "last_name": {
+                    "name": "last_name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "is_active": {
+                    "name": "is_active",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": false,
+                    "default": true
+                },
+                "dashboard_config": {
+                    "name": "dashboard_config",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "users_email_idx": {
+                    "name": "users_email_idx",
+                    "columns": [
+                        {
+                            "expression": "email",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_username_idx": {
+                    "name": "users_username_idx",
+                    "columns": [
+                        {
+                            "expression": "username",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_is_active_idx": {
+                    "name": "users_is_active_idx",
+                    "columns": [
+                        {
+                            "expression": "is_active",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                },
+                "users_created_at_idx": {
+                    "name": "users_created_at_idx",
+                    "columns": [
+                        {
+                            "expression": "created_at",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "users_email_unique": {
+                    "name": "users_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                },
+                "users_username_unique": {
+                    "name": "users_username_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["username"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {
+        "public.corkboard_post_type": {
+            "name": "corkboard_post_type",
+            "schema": "public",
+            "values": ["note", "photo"]
+        }
+    },
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -1,20 +1,27 @@
 {
-  "version": "7",
-  "dialect": "postgresql",
-  "entries": [
-    {
-      "idx": 0,
-      "version": "7",
-      "when": 1759778404604,
-      "tag": "0000_plain_the_fury",
-      "breakpoints": true
-    },
-    {
-      "idx": 1,
-      "version": "7",
-      "when": 1759842468492,
-      "tag": "0001_optimal_pestilence",
-      "breakpoints": true
-    }
-  ]
+    "version": "7",
+    "dialect": "postgresql",
+    "entries": [
+        {
+            "idx": 0,
+            "version": "7",
+            "when": 1759778404604,
+            "tag": "0000_plain_the_fury",
+            "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "7",
+            "when": 1759842468492,
+            "tag": "0001_optimal_pestilence",
+            "breakpoints": true
+        },
+        {
+            "idx": 2,
+            "version": "7",
+            "when": 1759862956493,
+            "tag": "0002_elite_firebird",
+            "breakpoints": true
+        }
+    ]
 }

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
             "when": 1759862956493,
             "tag": "0002_elite_firebird",
             "breakpoints": true
+        },
+        {
+            "idx": 3,
+            "version": "7",
+            "when": 1759916120260,
+            "tag": "0003_amused_jack_flag",
+            "breakpoints": true
         }
     ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -132,11 +132,69 @@ export const corkboardPosts = pgTable(
     },
 );
 
+export const families = pgTable("families", {
+    id: uuid("id")
+        .primaryKey()
+        .default(sql`uuidv7()`),
+    name: text("name").notNull(),
+    creator_id: uuid("creator_id")
+        .notNull()
+        .references(() => users.id, { onDelete: "cascade" }),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at")
+        .notNull()
+        .default(sql`now()`),
+    deleted_at: timestamp("deleted_at"),
+});
+
+export const familyMembers = pgTable(
+    "family_members",
+    {
+        family_id: uuid("family_id")
+            .notNull()
+            .references(() => families.id, { onDelete: "cascade" }),
+        user_id: uuid("user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        role: text("role").notNull(), // e.g., 'manager', 'member'
+    },
+    (table) => {
+        return {
+            pk: primaryKey({ columns: [table.family_id, table.user_id] }),
+        };
+    },
+);
+
+export const familyInvitations = pgTable("family_invitations", {
+    id: uuid("id")
+        .primaryKey()
+        .default(sql`uuidv7()`),
+    family_id: uuid("family_id")
+        .notNull()
+        .references(() => families.id, { onDelete: "cascade" }),
+    invited_by_user_id: uuid("invited_by_user_id")
+        .notNull()
+        .references(() => users.id, { onDelete: "cascade" }),
+    invited_email: text("invited_email").notNull(),
+    token: text("token").notNull().unique(),
+    status: text("status").notNull().default("pending"), // e.g., 'pending', 'accepted', 'declined'
+    expires_at: timestamp("expires_at").notNull(),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at")
+        .notNull()
+        .default(sql`now()`),
+});
+
 // Relations
 export const usersRelations = relations(users, ({ many }) => ({
     userRoles: many(userRoles),
     sessions: many(sessions),
     corkboardPosts: many(corkboardPosts),
+    familyMembers: many(familyMembers),
+    createdFamilies: many(families, { relationName: "creator" }),
+    sentFamilyInvitations: many(familyInvitations, {
+        relationName: "inviter",
+    }),
 }));
 
 export const rolesRelations = relations(roles, ({ many }) => ({
@@ -167,3 +225,39 @@ export const corkboardPostsRelations = relations(corkboardPosts, ({ one }) => ({
         references: [users.id],
     }),
 }));
+
+export const familiesRelations = relations(families, ({ one, many }) => ({
+    creator: one(users, {
+        fields: [families.creator_id],
+        references: [users.id],
+        relationName: "creator",
+    }),
+    members: many(familyMembers),
+    invitations: many(familyInvitations),
+}));
+
+export const familyMembersRelations = relations(familyMembers, ({ one }) => ({
+    family: one(families, {
+        fields: [familyMembers.family_id],
+        references: [families.id],
+    }),
+    user: one(users, {
+        fields: [familyMembers.user_id],
+        references: [users.id],
+    }),
+}));
+
+export const familyInvitationsRelations = relations(
+    familyInvitations,
+    ({ one }) => ({
+        family: one(families, {
+            fields: [familyInvitations.family_id],
+            references: [families.id],
+        }),
+        invitedByUser: one(users, {
+            fields: [familyInvitations.invited_by_user_id],
+            references: [users.id],
+            relationName: "inviter",
+        }),
+    }),
+);

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -116,6 +116,9 @@ export const corkboardPosts = pgTable(
         userId: uuid("user_id")
             .notNull()
             .references(() => users.id, { onDelete: "cascade" }),
+        family_id: uuid("family_id").references(() => families.id, {
+            onDelete: "set null",
+        }),
         type: corkboardPostTypeEnum("type").notNull(),
         data: jsonb("data"), // JSONB for content (note text or photo URL/caption)
         createdAt: timestamp("created_at").notNull().defaultNow(),
@@ -124,6 +127,9 @@ export const corkboardPosts = pgTable(
     (table) => {
         return {
             userIdIndex: index("corkboard_posts_user_id_idx").on(table.userId),
+            familyIdIndex: index("corkboard_posts_family_id_idx").on(
+                table.family_id,
+            ),
             typeIndex: index("corkboard_posts_type_idx").on(table.type),
             createdAtIndex: index("corkboard_posts_created_at_idx").on(
                 table.createdAt,
@@ -132,20 +138,33 @@ export const corkboardPosts = pgTable(
     },
 );
 
-export const families = pgTable("families", {
-    id: uuid("id")
-        .primaryKey()
-        .default(sql`uuidv7()`),
-    name: text("name").notNull(),
-    creator_id: uuid("creator_id")
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-    created_at: timestamp("created_at").notNull().defaultNow(),
-    updated_at: timestamp("updated_at")
-        .notNull()
-        .default(sql`now()`),
-    deleted_at: timestamp("deleted_at"),
-});
+export const families = pgTable(
+    "families",
+    {
+        id: uuid("id")
+            .primaryKey()
+            .default(sql`uuidv7()`),
+        name: text("name").notNull(),
+        creator_id: uuid("creator_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        created_at: timestamp("created_at").notNull().defaultNow(),
+        updated_at: timestamp("updated_at")
+            .notNull()
+            .default(sql`now()`),
+        deleted_at: timestamp("deleted_at"),
+    },
+    (table) => {
+        return {
+            creatorIdIndex: index("families_creator_id_idx").on(
+                table.creator_id,
+            ),
+            deletedAtIndex: index("families_deleted_at_idx").on(
+                table.deleted_at,
+            ),
+        };
+    },
+);
 
 export const familyMembers = pgTable(
     "family_members",
@@ -161,29 +180,43 @@ export const familyMembers = pgTable(
     (table) => {
         return {
             pk: primaryKey({ columns: [table.family_id, table.user_id] }),
+            userIdIndex: index("family_members_user_id_idx").on(table.user_id),
         };
     },
 );
 
-export const familyInvitations = pgTable("family_invitations", {
-    id: uuid("id")
-        .primaryKey()
-        .default(sql`uuidv7()`),
-    family_id: uuid("family_id")
-        .notNull()
-        .references(() => families.id, { onDelete: "cascade" }),
-    invited_by_user_id: uuid("invited_by_user_id")
-        .notNull()
-        .references(() => users.id, { onDelete: "cascade" }),
-    invited_email: text("invited_email").notNull(),
-    token: text("token").notNull().unique(),
-    status: text("status").notNull().default("pending"), // e.g., 'pending', 'accepted', 'declined'
-    expires_at: timestamp("expires_at").notNull(),
-    created_at: timestamp("created_at").notNull().defaultNow(),
-    updated_at: timestamp("updated_at")
-        .notNull()
-        .default(sql`now()`),
-});
+export const familyInvitations = pgTable(
+    "family_invitations",
+    {
+        id: uuid("id")
+            .primaryKey()
+            .default(sql`uuidv7()`),
+        family_id: uuid("family_id")
+            .notNull()
+            .references(() => families.id, { onDelete: "cascade" }),
+        invited_by_user_id: uuid("invited_by_user_id")
+            .notNull()
+            .references(() => users.id, { onDelete: "cascade" }),
+        invited_email: text("invited_email").notNull(),
+        token: text("token").notNull().unique(),
+        status: text("status").notNull().default("pending"), // e.g., 'pending', 'accepted', 'declined'
+        expires_at: timestamp("expires_at").notNull(),
+        created_at: timestamp("created_at").notNull().defaultNow(),
+        updated_at: timestamp("updated_at")
+            .notNull()
+            .default(sql`now()`),
+    },
+    (table) => {
+        return {
+            familyIdIndex: index("family_invitations_family_id_idx").on(
+                table.family_id,
+            ),
+            invitedEmailIndex: index("family_invitations_invited_email_idx").on(
+                table.invited_email,
+            ),
+        };
+    },
+);
 
 // Relations
 export const usersRelations = relations(users, ({ many }) => ({
@@ -224,6 +257,10 @@ export const corkboardPostsRelations = relations(corkboardPosts, ({ one }) => ({
         fields: [corkboardPosts.userId],
         references: [users.id],
     }),
+    family: one(families, {
+        fields: [corkboardPosts.family_id],
+        references: [families.id],
+    }),
 }));
 
 export const familiesRelations = relations(families, ({ one, many }) => ({
@@ -234,6 +271,7 @@ export const familiesRelations = relations(families, ({ one, many }) => ({
     }),
     members: many(familyMembers),
     invitations: many(familyInvitations),
+    corkboardPosts: many(corkboardPosts),
 }));
 
 export const familyMembersRelations = relations(familyMembers, ({ one }) => ({

--- a/server/db/seed.ts
+++ b/server/db/seed.ts
@@ -1,4 +1,4 @@
-import { customHashPassword } from "#server/utils/password";
+import { customHashPassword } from "../utils/password";
 import { logger } from "../utils/logger";
 import { db } from "./index";
 import { roles, userRoles, users } from "./schema";
@@ -6,13 +6,9 @@ import { roles, userRoles, users } from "./schema";
 async function seed() {
     logger.info("Starting database seeding...");
 
-    const email = "test@example.com";
-    const username = "admin";
-    const password = "password123";
-    const hashedPassword: string = await customHashPassword(password);
-
     try {
-        // 1. Seed roles
+        // 1. Seed Roles
+        logger.info("Seeding roles...");
         const roleData = [
             {
                 name: "admin",
@@ -20,61 +16,62 @@ async function seed() {
             },
             { name: "user", description: "Standard user role" },
         ];
+        await db.insert(roles).values(roleData).onConflictDoNothing();
 
-        for (const role of roleData) {
-            const existingRole = await db.query.roles.findFirst({
-                where: (roles, { eq }) =>
-                    eq(roles.name, role.name as "admin" | "user"),
-            });
-            if (!existingRole) {
-                await db.insert(roles).values(role);
-                logger.info(`Role '${role.name}' seeded.`);
-            }
+        const seededRoles = await db.query.roles.findMany();
+        const adminRole = seededRoles.find((r) => r.name === "admin");
+        const userRole = seededRoles.find((r) => r.name === "user");
+
+        if (!adminRole || !userRole) {
+            throw new Error("Admin or user role not found after seeding.");
         }
 
-        const adminRole = await db.query.roles.findFirst({
-            where: (roles, { eq }) => eq(roles.name, "admin"),
-        });
-
-        if (!adminRole) {
-            logger.error("Admin role not found after seeding. Exiting.");
-            process.exit(1);
-        }
-
-        // 2. Check if the admin user already exists
-        const existingUser = await db.query.users.findFirst({
-            where: (users, { eq }) => eq(users.email, email),
-        });
-
-        if (existingUser) {
-            logger.info(
-                `User with email ${email} already exists. Skipping insertion.`,
-            );
-            return;
-        }
-
-        // 3. Insert the test user
-        const [newUser] = await db
+        // 2. Seed Admin User
+        logger.info("Attempting to seed admin user...");
+        await db
             .insert(users)
             .values({
-                email,
-                username,
-                password: hashedPassword,
+                email: "admin@example.com",
+                username: "admin",
+                password: await customHashPassword("password123"),
                 display_name: "Test Admin",
-                first_name: "Test",
-                last_name: "Admin",
             })
-            .returning();
+            .onConflictDoNothing();
 
-        logger.info(`Successfully seeded user: ${newUser.email}`);
+        // 3. Seed Standard User for E2E Testing
+        logger.info("Attempting to seed standard test user...");
+        const testUserId = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"; // Predictable ID
+        await db
+            .insert(users)
+            .values({
+                id: testUserId,
+                email: "user@example.com",
+                username: "testuser",
+                password: await customHashPassword("password123"),
+                display_name: "Test User",
+            })
+            .onConflictDoNothing();
 
-        // 4. Assign 'admin' role to the new user
-        await db.insert(userRoles).values({
-            userId: newUser.id,
-            roleId: adminRole.id,
+        // 4. Assign roles idempotently
+        const adminUser = await db.query.users.findFirst({
+            where: (users, { eq }) => eq(users.username, "admin"),
         });
+        if (adminUser) {
+            await db
+                .insert(userRoles)
+                .values({ userId: adminUser.id, roleId: adminRole.id })
+                .onConflictDoNothing();
+        }
 
-        logger.info(`Assigned 'admin' role to user ${newUser.email}`);
+        const testUser = await db.query.users.findFirst({
+            where: (users, { eq }) => eq(users.id, testUserId),
+        });
+        if (testUser) {
+            await db
+                .insert(userRoles)
+                .values({ userId: testUser.id, roleId: userRole.id })
+                .onConflictDoNothing();
+        }
     } catch (error) {
         logger.error("Error during database seeding:", error);
         process.exit(1);

--- a/server/utils/email-sender.ts
+++ b/server/utils/email-sender.ts
@@ -28,6 +28,10 @@ interface SendInvitationEmailOptions {
 /**
  * Sends a family invitation email.
  * @param options - The details for the invitation email.
+ * @param options.token - The invitation token to include in the email link.
+ * @param options.familyName - The name of the family being invited to.
+ * @param options.inviterName - The name of the person sending the invitation.
+ * @param options.to - The recipient's email address.
  */
 export async function sendInvitationEmail(options: SendInvitationEmailOptions) {
     const { to, token, familyName, inviterName } = options;

--- a/server/utils/email-sender.ts
+++ b/server/utils/email-sender.ts
@@ -1,0 +1,59 @@
+import nodemailer from "nodemailer";
+import { logger } from "#server/utils/logger";
+
+// Configuration for the email transporter is pulled from environment variables.
+// This keeps sensitive credentials out of the source code.
+const smtpConfig = {
+    host: process.env.MAILERSEND_SMTP_HOST,
+    port: parseInt(process.env.MAILERSEND_SMTP_PORT || "587", 10),
+    secure: process.env.MAILERSEND_SMTP_SECURE === "true", // Use true for port 465, false for 587/2525
+    auth: {
+        user: process.env.MAILERSEND_SMTP_USER,
+        pass: process.env.MAILERSEND_SMTP_PASS,
+    },
+};
+
+// We create a single, reusable transporter object.
+const transporter = nodemailer.createTransport(smtpConfig);
+
+logger.info("Email transporter configured.");
+
+interface SendInvitationEmailOptions {
+    to: string;
+    token: string;
+    familyName: string;
+    inviterName: string;
+}
+
+/**
+ * Sends a family invitation email.
+ * @param options - The details for the invitation email.
+ */
+export async function sendInvitationEmail(options: SendInvitationEmailOptions) {
+    const { to, token, familyName, inviterName } = options;
+
+    // The base URL of the application should also be an environment variable.
+    const appBaseUrl =
+        process.env.NUXT_PUBLIC_APP_BASE_URL || "http://localhost:3000";
+    const invitationUrl = `${appBaseUrl}/invitations/${token}`;
+
+    const mailOptions = {
+        from: `Klankern <${process.env.MAIL_FROM_ADDRESS}>`,
+        to,
+        subject: `You're invited to join the "${familyName}" family on Klankern`,
+        text: `Hello,\n\n${inviterName} has invited you to join their family group, "${familyName}".\n\nClick the link below to accept:\n${invitationUrl}\n\nIf you were not expecting this, please ignore this email.\n\nThanks,\nThe Klankern Team`,
+        html: `<p>Hello,</p><p>${inviterName} has invited you to join their family group, "<strong>${familyName}</strong>".</p><p><a href="${invitationUrl}">Click here to accept the invitation.</a></p><p>If you were not expecting this, please ignore this email.</p><p>Thanks,<br>The Klankern Team</p>`,
+    };
+
+    try {
+        const info = await transporter.sendMail(mailOptions);
+        logger.info(
+            `Invitation email sent to ${to}. Message ID: ${info.messageId}`,
+        );
+        return info;
+    } catch (error) {
+        logger.error(`Failed to send invitation email to ${to}.`, { error });
+        // Re-throw a generic error to avoid leaking implementation details to the client.
+        throw new Error("Failed to send invitation email.");
+    }
+}

--- a/shared/types/family.ts
+++ b/shared/types/family.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * @fileoverview Shared types and validation schemas for the Family feature.
+ */
+
+// Zod schema for creating a new family. Used for request body validation.
+export const FamilyCreateSchema = z.object({
+    name: z
+        .string({
+            required_error: "Family name is required.",
+        })
+        .min(1, "Family name cannot be empty.")
+        .max(100, "Family name cannot exceed 100 characters."),
+});
+
+// Zod schema representing a complete family object, mirroring the database schema.
+export const FamilySchema = z.object({
+    id: z.string().uuid(),
+    name: z.string(),
+    creator_id: z.string().uuid(),
+    created_at: z.date(),
+    updated_at: z.date(),
+    deleted_at: z.date().nullable(),
+});
+
+// Inferred TypeScript type for a family object.
+export type Family = z.infer<typeof FamilySchema>;
+
+// Inferred TypeScript type for creating a family.
+export type FamilyCreate = z.infer<typeof FamilyCreateSchema>;

--- a/shared/types/invitation.ts
+++ b/shared/types/invitation.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+/**
+ * @fileoverview Shared types and validation schemas for the Invitation feature.
+ */
+
+// Zod schema for creating a new invitation. Used for request body validation.
+export const InvitationCreateSchema = z.object({
+    email: z
+        .string({
+            required_error: "Email address is required.",
+        })
+        .email("Invalid email address provided."),
+});
+
+// Inferred TypeScript type for creating an invitation.
+export type InvitationCreate = z.infer<typeof InvitationCreateSchema>;

--- a/test/e2e/family-creation.spec.ts
+++ b/test/e2e/family-creation.spec.ts
@@ -1,0 +1,24 @@
+// @vitest-environment nuxt
+
+import { describe, test, expect } from "vitest";
+import { setup } from "@nuxt/test-utils/e2e";
+
+/**
+ * @description E2E test for the family creation user flow.
+ */
+describe("E2E: Family Creation", async () => {
+    // This sets up the Nuxt environment in development mode, which enables hot-reloading for new files.
+    await setup({ browser: true, dev: true });
+
+    test("authentication endpoint should not exist yet", async () => {
+        // This test is the "Red" step. It proves the endpoint doesn't exist.
+        await expect(
+            $fetch("/api/__test__/login", {
+                method: "POST",
+                body: { userId: "any-id" },
+            }),
+        ).rejects.toMatchObject({
+            statusCode: 404,
+        });
+    }, 30000);
+});

--- a/test/nuxt/api/families.spec.ts
+++ b/test/nuxt/api/families.spec.ts
@@ -1,0 +1,129 @@
+import { registerEndpoint } from "@nuxt/test-utils/runtime";
+import { createError, readBody } from "h3";
+import { describe, expect, it, vi } from "vitest";
+
+// Mock the database dependency
+const mockDb = {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockResolvedValue([{ id: "new-family-id" }]),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockResolvedValue([]),
+};
+
+vi.mock("#server/db", () => ({
+    db: mockDb,
+}));
+
+describe("Families API Endpoints", () => {
+    const authenticatedUser = {
+        id: "user-123",
+        email: "test@example.com",
+        roles: [{ name: "user" }],
+    };
+
+    describe("GET /api/families", () => {
+        it("should return 401 for unauthenticated users", async () => {
+            registerEndpoint("/api/families", {
+                method: "GET",
+                handler: (event) => {
+                    if (!event.context.user) {
+                        throw createError({ statusCode: 401 });
+                    }
+                    return [];
+                },
+            });
+
+            await expect($fetch("/api/families")).rejects.toMatchObject({
+                statusCode: 401,
+            });
+        });
+
+        it("should return an array of families for an authenticated user", async () => {
+            const mockFamilies = [
+                { id: "family-1", name: "Family 1" },
+                { id: "family-2", name: "Family 2" },
+            ];
+
+            registerEndpoint("/api/families", {
+                method: "GET",
+                handler: (event) => {
+                    event.context.user = authenticatedUser;
+                    // This is a simplified mock. The real endpoint would query the DB.
+                    return mockFamilies;
+                },
+            });
+
+            const response = await $fetch("/api/families");
+            expect(response).toEqual(mockFamilies);
+            expect(response.length).toBe(2);
+        });
+    });
+
+    describe("POST /api/families", () => {
+        const validFamilyData = { name: "My New Family" };
+
+        it("should return 401 for unauthenticated users", async () => {
+            registerEndpoint("/api/families", {
+                method: "POST",
+                handler: (event) => {
+                    if (!event.context.user) {
+                        throw createError({ statusCode: 401 });
+                    }
+                    return {};
+                },
+            });
+
+            await expect(
+                $fetch("/api/families", {
+                    method: "POST",
+                    body: validFamilyData,
+                }),
+            ).rejects.toMatchObject({ statusCode: 401 });
+        });
+
+        it("should return 400 for invalid data (e.g., missing name)", async () => {
+            registerEndpoint("/api/families", {
+                method: "POST",
+                handler: async (event) => {
+                    event.context.user = authenticatedUser;
+                    const body = await readBody(event);
+                    if (!body.name) {
+                        throw createError({ statusCode: 400 });
+                    }
+                    return {};
+                },
+            });
+
+            await expect(
+                $fetch("/api/families", { method: "POST", body: { name: "" } }),
+            ).rejects.toMatchObject({ statusCode: 400 });
+        });
+
+        it("should create a family and return it", async () => {
+            const newFamily = {
+                id: "new-family-id",
+                name: validFamilyData.name,
+            };
+
+            registerEndpoint("/api/families", {
+                method: "POST",
+                handler: async (event) => {
+                    event.context.user = authenticatedUser;
+                    const body = await readBody(event);
+                    if (!body.name) {
+                        throw createError({ statusCode: 400 });
+                    }
+                    // Simplified mock of DB insertion
+                    return newFamily;
+                },
+            });
+
+            const response = await $fetch("/api/families", {
+                method: "POST",
+                body: validFamilyData,
+            });
+
+            expect(response).toEqual(newFamily);
+        });
+    });
+});

--- a/test/nuxt/api/families/invitations.spec.ts
+++ b/test/nuxt/api/families/invitations.spec.ts
@@ -1,0 +1,142 @@
+import { registerEndpoint } from "@nuxt/test-utils/runtime";
+import { createError, readBody } from "h3";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the email sender utility
+const mockSendInvitationEmail = vi.fn();
+vi.mock("~/server/utils/email-sender", () => ({
+    sendInvitationEmail: mockSendInvitationEmail,
+}));
+
+// Mock the database dependency
+const mockDb = {
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockResolvedValue([{ id: "new-invitation-id" }]),
+    query: {
+        familyMembers: {
+            findFirst: vi.fn().mockResolvedValue(null), // Default to user not being a member
+        },
+    },
+};
+
+vi.mock("#server/db", () => ({
+    db: mockDb,
+}));
+
+describe("POST /api/families/:familyId/invitations", () => {
+    const familyId = "family-123";
+    const managerUser = {
+        id: "user-manager-123",
+        roles: [{ name: "user" }],
+    };
+    const regularUser = {
+        id: "user-regular-456",
+        roles: [{ name: "user" }],
+    };
+    const validInvitationBody = { email: "new.member@example.com" };
+
+    // Reset mocks before each test
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("should return 401 for unauthenticated users", async () => {
+        registerEndpoint(`/api/families/${familyId}/invitations`, {
+            method: "POST",
+            handler: (event) => {
+                if (!event.context.user) {
+                    throw createError({ statusCode: 401 });
+                }
+                return {};
+            },
+        });
+
+        await expect(
+            $fetch(`/api/families/${familyId}/invitations`, {
+                method: "POST",
+                body: validInvitationBody,
+            }),
+        ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it("should return 403 if the user is not a manager of the family", async () => {
+        // Mock DB to return that the user is a regular member, not a manager
+        mockDb.query.familyMembers.findFirst.mockResolvedValueOnce({
+            role: "member",
+        });
+
+        registerEndpoint(`/api/families/${familyId}/invitations`, {
+            method: "POST",
+            handler: async (event) => {
+                event.context.user = regularUser;
+                // Simplified mock of authorization logic
+                const membership = await mockDb.query.familyMembers.findFirst();
+                if (membership?.role !== "manager") {
+                    throw createError({ statusCode: 403 });
+                }
+                return {};
+            },
+        });
+
+        await expect(
+            $fetch(`/api/families/${familyId}/invitations`, {
+                method: "POST",
+                body: validInvitationBody,
+            }),
+        ).rejects.toMatchObject({ statusCode: 403 });
+    });
+
+    it("should return 400 for an invalid email", async () => {
+        registerEndpoint(`/api/families/${familyId}/invitations`, {
+            method: "POST",
+            handler: async (event) => {
+                event.context.user = managerUser;
+                const body = await readBody(event);
+                if (!body.email || !body.email.includes("@")) {
+                    throw createError({ statusCode: 400 });
+                }
+                return {};
+            },
+        });
+
+        await expect(
+            $fetch(`/api/families/${familyId}/invitations`, {
+                method: "POST",
+                body: { email: "invalid" },
+            }),
+        ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it("should successfully create an invitation and send an email", async () => {
+        // Mock DB to return that the user is a manager
+        mockDb.query.familyMembers.findFirst.mockResolvedValueOnce({
+            role: "manager",
+        });
+
+        registerEndpoint(`/api/families/${familyId}/invitations`, {
+            method: "POST",
+            handler: async (event) => {
+                event.context.user = managerUser;
+                const body = await readBody(event);
+
+                // Simplified mock of the full logic
+                await mockDb.insert().values({}); // Mock DB insert
+                await mockSendInvitationEmail({ to: body.email }); // Mock email send
+
+                return { message: "Invitation sent successfully" };
+            },
+        });
+
+        const response = await $fetch(`/api/families/${familyId}/invitations`, {
+            method: "POST",
+            body: validInvitationBody,
+        });
+
+        expect(response.message).toBe("Invitation sent successfully");
+        // Verify that the email sending function was called
+        expect(mockSendInvitationEmail).toHaveBeenCalledOnce();
+        expect(mockSendInvitationEmail).toHaveBeenCalledWith({
+            to: validInvitationBody.email,
+        });
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
             await defineVitestProject({
                 test: {
                     name: "nuxt",
-                    include: ["test/nuxt/**/*.{test,spec}.ts"],
+                    include: [
+                        "test/nuxt/**/*.{test,spec}.ts",
+                        "test/e2e/**/*.{test,spec}.ts",
+                    ],
                     environment: "nuxt",
                     setupFiles: ["./test/setup.ts"],
                 },


### PR DESCRIPTION
Implements the full backend and frontend for the family management feature. Adds a complete, but currently non-functional, E2E test setup for creating families.

- Backend: Full CRUD for families, members, and a complete invitation lifecycle (send, accept, decline). Includes soft-deletes and performance indexes.
- Frontend: Vue pages and Pinia stores for creating families, viewing a family dashboard, listing members, sending invitations, and accepting/declining invitations.
- E2E Setup: Adds Playwright, a test-only auth endpoint, a predictable test user, and a non-working E2E test for the family creation flow. The test is blocked by an unresolved issue with the Nuxt test server not discovering new routes.
- Docs: Updates AGENTS.md with new guidelines and test user credentials.