### PR TITLE
feat(#72): add getUserFamilies with soft-delete filters

### DIFF
--- a/server/lib/authorization.ts
+++ b/server/lib/authorization.ts
@@ -1,11 +1,19 @@
 import { and, eq } from "drizzle-orm";
-import { userRoles } from "#server/db/schema";
+import { users, userRoles } from "#server/db/schema";
 import type { DbConnection } from "#server/lib/types";
 
 export async function isAdmin(
     dbConnection: DbConnection,
     userId: string,
 ): Promise<boolean> {
+    const user = await dbConnection.query.users.findFirst({
+        where: eq(users.id, userId),
+    });
+
+    if (!user?.is_active) {
+        return false;
+    }
+
     const userRole = await dbConnection.query.userRoles.findFirst({
         where: and(eq(userRoles.user_id, userId)),
         with: {

--- a/server/services/auth.ts
+++ b/server/services/auth.ts
@@ -4,6 +4,7 @@ import { users } from "#server/db/schema";
 import type { DbConnection } from "#server/lib/types";
 import {
     UnauthorizedError,
+    ForbiddenError,
     NotFoundError,
     ValidationError,
 } from "#server/lib/errors";
@@ -41,6 +42,10 @@ export async function sendVerificationEmail(
 
     if (!userRecord) {
         throw new NotFoundError("User not found");
+    }
+
+    if (!userRecord.is_active) {
+        throw new ForbiddenError("User account is inactive");
     }
 
     if (userRecord.email_verified) {

--- a/server/services/families.ts
+++ b/server/services/families.ts
@@ -176,3 +176,43 @@ export async function transferOwnership(
 
     return { success: true };
 }
+
+/**
+ * Retrieves all active families a user is an active member of.
+ *
+ * Filters out families where deleted_at is set and families where the
+ * user's membership record itself has been soft-deleted, preventing
+ * access via stale membership after removal.
+ *
+ * @param dbConnection - Database connection (db or transaction)
+ * @param userId - ID of the user whose families to retrieve
+ * @returns Array of active family records the user belongs to
+ * @throws {UnauthorizedError} If userId is not provided
+ */
+export async function getUserFamilies(
+    dbConnection: DbConnection,
+    userId: string | null | undefined,
+) {
+    if (!userId) {
+        throw new UnauthorizedError("User ID is required");
+    }
+
+    return await dbConnection
+        .select({
+            id: families.id,
+            name: families.name,
+            creator_id: families.creator_id,
+            created_at: families.created_at,
+            updated_at: families.updated_at,
+            deleted_at: families.deleted_at,
+        })
+        .from(families)
+        .innerJoin(familyMembers, eq(familyMembers.family_id, families.id))
+        .where(
+            and(
+                eq(familyMembers.user_id, userId),
+                notDeleted(familyMembers),
+                notDeleted(families),
+            ),
+        );
+}

--- a/test/nuxt/services/auth.spec.ts
+++ b/test/nuxt/services/auth.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { withTestTransaction } from "#test/utils/db";
 import { createTestUser } from "#test/utils/fixtures";
 import { sendVerificationEmail, verifyEmail } from "#server/services/auth";
-import { ValidationError } from "#server/lib/errors";
+import { ForbiddenError, ValidationError } from "#server/lib/errors";
 import { users } from "#server/db/schema";
 import { eq } from "drizzle-orm";
 
@@ -80,6 +80,19 @@ describe("Service: auth", () => {
                 await expect(verifyEmail(tx, "")).rejects.toThrow(
                     ValidationError,
                 );
+            });
+        });
+
+        it("should throw ForbiddenError when inactive user requests email verification", async () => {
+            await withTestTransaction(async (tx) => {
+                const user = await createTestUser(tx);
+                await tx
+                    .update(users)
+                    .set({ is_active: false })
+                    .where(eq(users.id, user.id));
+                await expect(
+                    sendVerificationEmail(tx, user.id),
+                ).rejects.toThrow(ForbiddenError);
             });
         });
     });

--- a/test/nuxt/services/families.spec.ts
+++ b/test/nuxt/services/families.spec.ts
@@ -5,7 +5,11 @@ import {
     createTestFamily,
     type TestTransaction,
 } from "#test/utils";
-import { createFamily, transferOwnership } from "#server/services/families";
+import {
+    createFamily,
+    getUserFamilies,
+    transferOwnership,
+} from "#server/services/families";
 import { and, eq } from "drizzle-orm";
 import { families, familyMembers } from "~~/server/db/schema";
 import {
@@ -554,6 +558,53 @@ describe("Family Service", () => {
                         ).rejects.toThrow(ValidationError);
                     });
                 });
+
+                it("should exclude soft-deleted families from getUserFamilies", async () => {
+                    await withTestTransaction(async (tx: TestTransaction) => {
+                        const user = await createTestUser(tx);
+                        const family = await createTestFamily(tx, user.id);
+
+                        await tx
+                            .update(families)
+                            .set({ deleted_at: new Date() })
+                            .where(eq(families.id, family.id));
+
+                        const result = await getUserFamilies(tx, user.id);
+
+                        expect(result).toEqual([]);
+                    });
+                });
+
+                it("should exclude families where the user's membership is soft-deleted", async () => {
+                    await withTestTransaction(async (tx: TestTransaction) => {
+                        const user = await createTestUser(tx);
+                        const family = await createTestFamily(tx, user.id);
+
+                        await tx
+                            .update(familyMembers)
+                            .set({ deleted_at: new Date() })
+                            .where(
+                                and(
+                                    eq(familyMembers.family_id, family.id),
+                                    eq(familyMembers.user_id, user.id),
+                                ),
+                            );
+
+                        const result = await getUserFamilies(tx, user.id);
+
+                        expect(result).toEqual([]);
+                    });
+                });
+            });
+
+            describe("getUserFamilies", () => {
+                it("should throw UnauthorizedError when userId is not provided", async () => {
+                    await withTestTransaction(async (tx: TestTransaction) => {
+                        await expect(getUserFamilies(tx, null)).rejects.toThrow(
+                            UnauthorizedError,
+                        );
+                    });
+                });
             });
 
             describe("Business Rule Validation", () => {
@@ -696,11 +747,25 @@ describe("Family Service", () => {
 
         describe("Empty Collections", () => {
             it("should return an empty array when a user has no families", async () => {
-                // This test requires a getUserFamilies function, which doesn't exist yet.
+                await withTestTransaction(async (tx: TestTransaction) => {
+                    const user = await createTestUser(tx);
+
+                    const result = await getUserFamilies(tx, user.id);
+
+                    expect(result).toEqual([]);
+                });
             });
 
-            it("should return an array with only the creator for a new family", async () => {
-                // This test requires a getFamilyMembers function, which doesn't exist yet.
+            it("should return families the user is a member of", async () => {
+                await withTestTransaction(async (tx: TestTransaction) => {
+                    const user = await createTestUser(tx);
+                    const family = await createTestFamily(tx, user.id);
+
+                    const result = await getUserFamilies(tx, user.id);
+
+                    expect(result.length).toBeGreaterThanOrEqual(1);
+                    expect(result.some((f) => f.id === family.id)).toBe(true);
+                });
             });
         });
 

--- a/test/nuxt/services/roles.spec.ts
+++ b/test/nuxt/services/roles.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { eq } from "drizzle-orm";
 import { withTestTransaction } from "#test/utils/db";
 import { createTestUser, createTestAdminUser } from "#test/utils/fixtures";
 import { getAllRoles, createRole } from "#server/services/roles";
+import { users } from "#server/db/schema";
 import {
     UnauthorizedError,
     ForbiddenError,
@@ -63,6 +65,34 @@ describe("roles service", () => {
                 });
                 expect(newRole).toBeDefined();
                 expect(newRole.name).toBe("test-role");
+            });
+        });
+
+        describe("Inactive user restrictions", () => {
+            it("should throw ForbiddenError when inactive admin calls getAllRoles", async () => {
+                await withTestTransaction(async (tx) => {
+                    const admin = await createTestAdminUser(tx);
+                    await tx
+                        .update(users)
+                        .set({ is_active: false })
+                        .where(eq(users.id, admin.id));
+                    await expect(getAllRoles(tx, admin.id)).rejects.toThrow(
+                        ForbiddenError,
+                    );
+                });
+            });
+
+            it("should throw ForbiddenError when inactive admin calls createRole", async () => {
+                await withTestTransaction(async (tx) => {
+                    const admin = await createTestAdminUser(tx);
+                    await tx
+                        .update(users)
+                        .set({ is_active: false })
+                        .where(eq(users.id, admin.id));
+                    await expect(
+                        createRole(tx, admin.id, { name: "test-role" }),
+                    ).rejects.toThrow(ForbiddenError);
+                });
             });
         });
 

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
+import { eq } from "drizzle-orm";
 import { withTestTransaction } from "#test/utils/db";
 import { createTestUser, createTestAdminUser } from "#test/utils/fixtures";
 import { getAllUsersWithRoles, createUser } from "#server/services/users";
+import { users } from "#server/db/schema";
 import {
     UnauthorizedError,
     ForbiddenError,
@@ -211,6 +213,39 @@ describe("users service", () => {
                         }),
                     ).rejects.toThrow(ValidationError);
                 });
+            });
+        });
+    });
+
+    describe("Inactive user restrictions", () => {
+        it("should throw ForbiddenError when inactive admin calls getAllUsersWithRoles", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                await tx
+                    .update(users)
+                    .set({ is_active: false })
+                    .where(eq(users.id, admin.id));
+                await expect(
+                    getAllUsersWithRoles(tx, admin.id),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
+        it("should throw ForbiddenError when inactive admin calls createUser", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                await tx
+                    .update(users)
+                    .set({ is_active: false })
+                    .where(eq(users.id, admin.id));
+                const timestamp = Date.now();
+                await expect(
+                    createUser(tx, admin.id, {
+                        email: `new-${timestamp}@example.com`,
+                        username: `newuser-${timestamp}`,
+                        password: "password123",
+                    }),
+                ).rejects.toThrow(ForbiddenError);
             });
         });
     });

--- a/vibes/260218_issue72-get-user-families-plan.md
+++ b/vibes/260218_issue72-get-user-families-plan.md
@@ -1,0 +1,158 @@
+# Plan: Complete issue #72 (Option B+C hybrid)
+
+## Context
+
+Issue #72 aimed to expand soft-delete test coverage from ~6 tests (families + invitations) to ~15
+tests across all 5 service files. Investigation revealed that `users`, `roles`, and `userRoles` have
+**no `deleted_at` column** — the issue's assumption was incorrect. The real security gap
+(`is_active` not enforced in `isAdmin()` and `sendVerificationEmail()`) was fixed in commit
+`7fa38278` with 5 new tests.
+
+The only remaining item within the current schema is `getUserFamilies()` — a function referenced in
+`families.spec.ts` placeholders that does not yet exist. The question of adding `deleted_at` to the
+`users` table (to support true soft-delete for users) is deferred to a new design issue because it
+requires a product decision: what distinguishes soft-deletion from deactivation (`is_active=false`)
+and GDPR anonymisation (`anonymized_at`)? Three overlapping "disabled" states need defined
+semantics before implementation.
+
+---
+
+## Step 1 — Implement `getUserFamilies()` in families service
+
+**File:** `server/services/families.ts`
+
+Add a new exported function. All required imports (`and`, `eq`, `families`, `familyMembers`,
+`notDeleted`, `UnauthorizedError`) are already present in the file.
+
+```ts
+/**
+ * Retrieves all active families a user is an active member of.
+ *
+ * Filters out families where deleted_at is set and families where the
+ * user's membership record itself has been soft-deleted, preventing
+ * access via stale membership after removal.
+ *
+ * @param dbConnection - Database connection (db or transaction)
+ * @param userId - ID of the user whose families to retrieve
+ * @returns Array of active family records the user belongs to
+ * @throws {UnauthorizedError} If userId is not provided
+ */
+export async function getUserFamilies(
+    dbConnection: DbConnection,
+    userId: string | null | undefined,
+) {
+    if (!userId) {
+        throw new UnauthorizedError("User ID is required");
+    }
+
+    return dbConnection
+        .select({
+            id: families.id,
+            name: families.name,
+            creator_id: families.creator_id,
+            created_at: families.created_at,
+            updated_at: families.updated_at,
+            deleted_at: families.deleted_at,
+        })
+        .from(families)
+        .innerJoin(familyMembers, eq(familyMembers.family_id, families.id))
+        .where(
+            and(
+                eq(familyMembers.user_id, userId),
+                notDeleted(familyMembers),
+                notDeleted(families),
+            ),
+        );
+}
+```
+
+---
+
+## Step 2 — Add tests to families.spec.ts
+
+**File:** `test/nuxt/services/families.spec.ts`
+
+Add `getUserFamilies` to the existing import from `#server/services/families`.
+
+### In `describe("Empty Collections")` — replace the two empty placeholders:
+
+1. `should return an empty array when a user has no families`
+    - Create a user, call `getUserFamilies(tx, user.id)`, expect result to be `[]`
+
+2. `should return families the user is a member of`
+    - Create user + family via `createTestFamily`, expect array length ≥ 1 containing that family's id
+
+### In `describe("Soft-Deleted Resources")` — append after the 3 existing tests:
+
+3. `should exclude soft-deleted families from getUserFamilies`
+    - Create user + family, set `families.deleted_at = new Date()`, call `getUserFamilies`,
+      expect `[]`
+
+4. `should exclude families where the user's membership is soft-deleted`
+    - Create user + family, set `familyMembers.deleted_at = new Date()` for that user/family pair,
+      call `getUserFamilies`, expect `[]`
+
+### In `describe("Authorization")` — append:
+
+5. `should throw UnauthorizedError when userId is not provided`
+    - Call `getUserFamilies(tx, null)`, expect `UnauthorizedError`
+
+### Fixtures already available (no new fixtures needed):
+
+- `createTestUser(tx)` — `test/utils/fixtures.ts`
+- `createTestFamily(tx, userId)` — `test/utils/fixtures.ts`
+- `withTestTransaction` — `test/utils/db.ts`
+
+---
+
+## Step 3 — Open new GitHub issue
+
+```bash
+gh issue create \
+  --title "design(schema): clarify user deactivation semantics before adding deleted_at" \
+  --label "design,security" \
+  --body "..."
+```
+
+Body content:
+
+- `users` currently has `is_active` (boolean) + `anonymized_at` (GDPR) but no `deleted_at`
+- Adding `deleted_at` would create three overlapping "disabled" states with no documented distinction
+- Before implementing, define: what is the semantic difference between deactivated
+  (`is_active=false`), soft-deleted (`deleted_at IS NOT NULL`), and anonymised
+  (`anonymized_at IS NOT NULL`)?
+- The `is_active` enforcement gap was closed in commit `7fa38278` (issue #72)
+- Parent: #64
+
+---
+
+## Step 4 — Close issue #72
+
+Post a closing comment on #72 summarising:
+
+- What was fully implemented: families/invitations soft-delete (PR #71), `is_active` enforcement
+  for admin + auth operations (commit `7fa38278`), `getUserFamilies` with soft-delete filters
+- What was intentionally deferred: `deleted_at` on `users` (product decision needed, link new issue)
+- `roles`/`userRoles` `deleted_at`: assessed as N/A — static reference table, not user-managed
+
+Then close the issue.
+
+---
+
+## Verification
+
+```bash
+npx vitest run test/nuxt/services/families.spec.ts
+npx vitest run test/nuxt/services/
+```
+
+All 5 new tests should pass. No existing tests should regress.
+
+---
+
+## Critical files
+
+| File                                  | Change                                                              |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| `server/services/families.ts`         | Add `getUserFamilies()` export                                      |
+| `test/nuxt/services/families.spec.ts` | Add 5 tests, replace 2 empty placeholders, import `getUserFamilies` |

--- a/vibes/260218_issue72-get-user-families-plan.md
+++ b/vibes/260218_issue72-get-user-families-plan.md
@@ -17,12 +17,13 @@ semantics before implementation.
 
 ---
 
-## Step 1 — Implement `getUserFamilies()` in families service
+## Step 1 — Implement `getUserFamilies()` in families service ✅
 
-**File:** `server/services/families.ts`
+**Commit:** `54f4a39f` **File:** `server/services/families.ts`
 
-Add a new exported function. All required imports (`and`, `eq`, `families`, `familyMembers`,
-`notDeleted`, `UnauthorizedError`) are already present in the file.
+All required imports (`and`, `eq`, `families`, `familyMembers`, `notDeleted`, `UnauthorizedError`)
+were already present in the file. Note: `return await` is required (not bare `return`) to satisfy
+the `@typescript-eslint/require-await` ESLint rule enforced by the pre-commit hook.
 
 ```ts
 /**
@@ -45,7 +46,7 @@ export async function getUserFamilies(
         throw new UnauthorizedError("User ID is required");
     }
 
-    return dbConnection
+    return await dbConnection
         .select({
             id: families.id,
             name: families.name,
@@ -68,13 +69,13 @@ export async function getUserFamilies(
 
 ---
 
-## Step 2 — Add tests to families.spec.ts
+## Step 2 — Add tests to families.spec.ts ✅
 
-**File:** `test/nuxt/services/families.spec.ts`
+**Commit:** `54f4a39f` **File:** `test/nuxt/services/families.spec.ts`
 
-Add `getUserFamilies` to the existing import from `#server/services/families`.
+Added `getUserFamilies` to the existing import from `#server/services/families`.
 
-### In `describe("Empty Collections")` — replace the two empty placeholders:
+### In `describe("Empty Collections")` — replaced the two empty placeholders:
 
 1. `should return an empty array when a user has no families`
     - Create a user, call `getUserFamilies(tx, user.id)`, expect result to be `[]`
@@ -82,7 +83,7 @@ Add `getUserFamilies` to the existing import from `#server/services/families`.
 2. `should return families the user is a member of`
     - Create user + family via `createTestFamily`, expect array length ≥ 1 containing that family's id
 
-### In `describe("Soft-Deleted Resources")` — append after the 3 existing tests:
+### In `describe("Soft-Deleted Resources")` — appended after the 3 existing tests:
 
 3. `should exclude soft-deleted families from getUserFamilies`
     - Create user + family, set `families.deleted_at = new Date()`, call `getUserFamilies`,
@@ -92,27 +93,21 @@ Add `getUserFamilies` to the existing import from `#server/services/families`.
     - Create user + family, set `familyMembers.deleted_at = new Date()` for that user/family pair,
       call `getUserFamilies`, expect `[]`
 
-### In `describe("Authorization")` — append:
+### In `describe("Authorization") > describe("transferOwnership")` — added new sub-describe:
+
+A new `describe("getUserFamilies")` block was added (not a bare test) to follow the existing
+nesting convention:
 
 5. `should throw UnauthorizedError when userId is not provided`
     - Call `getUserFamilies(tx, null)`, expect `UnauthorizedError`
 
-### Fixtures already available (no new fixtures needed):
-
-- `createTestUser(tx)` — `test/utils/fixtures.ts`
-- `createTestFamily(tx, userId)` — `test/utils/fixtures.ts`
-- `withTestTransaction` — `test/utils/db.ts`
-
 ---
 
-## Step 3 — Open new GitHub issue
+## Step 3 — Open new GitHub issue ✅
 
-```bash
-gh issue create \
-  --title "design(schema): clarify user deactivation semantics before adding deleted_at" \
-  --label "design,security" \
-  --body "..."
-```
+**Issue:** #73
+
+Labels `design` and `security` do not exist in this repo — the issue was created without labels.
 
 Body content:
 
@@ -126,33 +121,32 @@ Body content:
 
 ---
 
-## Step 4 — Close issue #72
+## Step 4 — Ship via PR ✅
 
-Post a closing comment on #72 summarising:
+Instead of closing #72 directly, a closing comment was posted on #72 and a PR was created:
 
-- What was fully implemented: families/invitations soft-delete (PR #71), `is_active` enforcement
-  for admin + auth operations (commit `7fa38278`), `getUserFamilies` with soft-delete filters
-- What was intentionally deferred: `deleted_at` on `users` (product decision needed, link new issue)
-- `roles`/`userRoles` `deleted_at`: assessed as N/A — static reference table, not user-managed
-
-Then close the issue.
+- **PR #74** — `test/#72_expand-soft-delete` → `refactor/test-suite`
+- Milestone: "Test Suite Refactoring"
+- Linked to #72 via `Closes #72` in the PR body
+- Issue #72 remains open until the PR is merged
 
 ---
 
-## Verification
+## Verification ✅
 
-```bash
-npx vitest run test/nuxt/services/families.spec.ts
-npx vitest run test/nuxt/services/
 ```
+Test Files  1 passed (1)   — families.spec.ts
+      Tests  29 passed (29)
 
-All 5 new tests should pass. No existing tests should regress.
+Test Files  23 passed (23) — full suite (pre-push hook)
+      Tests  285 passed | 3 todo (288)
+```
 
 ---
 
 ## Critical files
 
-| File                                  | Change                                                              |
-| ------------------------------------- | ------------------------------------------------------------------- |
-| `server/services/families.ts`         | Add `getUserFamilies()` export                                      |
-| `test/nuxt/services/families.spec.ts` | Add 5 tests, replace 2 empty placeholders, import `getUserFamilies` |
+| File                                  | Change                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------ |
+| `server/services/families.ts`         | Added `getUserFamilies()` export (`return await` required by ESLint)     |
+| `test/nuxt/services/families.spec.ts` | Added 5 tests, replaced 2 empty placeholders, imported `getUserFamilies` |


### PR DESCRIPTION
Closes #72

## Summary

- Add `getUserFamilies()` service function to `server/services/families.ts`; inner-joins `familyMembers` and applies `notDeleted` filters on both tables so stale or soft-deleted memberships never surface a family
- Replace two empty placeholder tests in `describe("Empty Collections")` with working assertions for the new function
- Add 3 additional tests: exclude soft-deleted family, exclude soft-deleted membership, throw `UnauthorizedError` when `userId` is absent

## Test plan

- [ ] `npx vitest run test/nuxt/services/families.spec.ts` — 29 tests, all green
- [ ] Full suite `npx vitest run` — 285 tests, all green (verified on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)