### PR TITLE
feat(#67): add admin hard-delete for users and families with tests

### DIFF
--- a/server/api/admin/families/[id].delete.ts
+++ b/server/api/admin/families/[id].delete.ts
@@ -4,35 +4,35 @@ import { db } from "#server/db";
 import { logger } from "#server/utils/logger";
 import { requireAdmin } from "#server/utils/auth";
 import { translateError } from "#server/lib/errors";
-import { deleteUser } from "#server/services/users";
+import { deleteFamily } from "#server/services/families";
 
-const userIdSchema = z.string().uuid("Invalid user ID format");
+const familyIdSchema = z.string().uuid("Invalid family ID format");
 
 export default defineEventHandler(async (event) => {
     logger.http(`${event.method} ${event.path}`);
     await requireAdmin(event);
 
-    const parsedUserId = userIdSchema.safeParse(event.context.params?.id);
+    const parsedFamilyId = familyIdSchema.safeParse(event.context.params?.id);
 
-    if (!parsedUserId.success) {
+    if (!parsedFamilyId.success) {
         throw createError({
             statusCode: 400,
-            statusMessage: "Invalid user ID",
-            data: parsedUserId.error.issues,
+            statusMessage: "Invalid family ID",
+            data: parsedFamilyId.error.issues,
         });
     }
 
     try {
-        const result = await deleteUser(
+        const result = await deleteFamily(
             db,
             event.context.user?.id,
-            parsedUserId.data,
+            parsedFamilyId.data,
         );
 
-        return { message: "User deleted successfully", id: result.id };
+        return { message: "Family deleted successfully", id: result.id };
     } catch (error) {
         logger.error(
-            `Error deleting user with ID ${parsedUserId.data}:`,
+            `Error deleting family with ID ${parsedFamilyId.data}:`,
             error,
         );
         throw translateError(error);

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -16,6 +16,7 @@ export class ForbiddenError extends DomainError {}
 export class NotFoundError extends DomainError {}
 export class ValidationError extends DomainError {}
 export class ConflictError extends DomainError {}
+export class InternalError extends DomainError {}
 
 /**
  * Translates domain errors to HTTP errors for route handlers.

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -64,6 +64,21 @@ export function translateError(error: unknown) {
         });
     }
 
+    // InternalError: Intentionally returns a generic message.
+    // The error message is for internal logging only and must not be exposed to clients.
+    if (error instanceof InternalError) {
+        logger.error("Internal service error:", {
+            message: error.message,
+            stack: error.stack,
+            name: error.name,
+        });
+
+        return createError({
+            statusCode: 500,
+            statusMessage: "An unexpected error occurred.",
+        });
+    }
+
     // System/unexpected errors: Log but don't expose details
     logger.error("Unexpected service error:", {
         message: error instanceof Error ? error.message : String(error),

--- a/server/services/README.md
+++ b/server/services/README.md
@@ -16,6 +16,7 @@ The service layer architecture solves a critical testing problem: **transaction-
 ### 1. Accept Database Connection as Parameter
 
 Services MUST accept a `DbConnection` as their first parameter. This can be either:
+
 - Production: The global `db` object
 - Test: A transaction object `tx` from `withTestTransaction()`
 
@@ -30,7 +31,7 @@ export async function createFamily(
         .insert(families)
         .values({ name: input.name, creator_id: userId })
         .returning();
-    
+
     return family;
 }
 ```
@@ -38,6 +39,7 @@ export async function createFamily(
 ### 2. Throw Domain Errors, Not HTTP Errors
 
 Services throw domain-specific errors from `server/lib/errors.ts`:
+
 - `UnauthorizedError` - User not authenticated
 - `ForbiddenError` - User lacks permission
 - `NotFoundError` - Resource not found
@@ -58,6 +60,7 @@ throw new UnauthorizedError("User ID is required");
 ### 3. Framework-Agnostic
 
 Services must NOT depend on:
+
 - H3 event handlers
 - HTTP request/response objects
 - Session management
@@ -68,6 +71,7 @@ All necessary data is passed as parameters.
 ### 4. No Transaction Management
 
 Services MUST NOT call `db.transaction()`. Transactions are managed by:
+
 - **Route handlers** in production
 - **Test utilities** (`withTestTransaction()`) in tests
 
@@ -102,9 +106,18 @@ Custom ESLint rules automatically enforce these patterns:
 
 These rules apply ONLY to files in `server/services/` directory.
 
+## Known Tech Debt
+
+### Double admin check per request
+
+Admin-only service functions (e.g. `deleteUser`, `deleteFamily`, `getAllUsersWithRoles`) re-check `isAdmin(dbConnection, userId)` even though the route handler already calls `requireAdmin(event)`. This results in two DB queries for the same privilege check on every admin request.
+
+The redundancy exists because services must be framework-agnostic and cannot rely on the route handler having already verified permissions. Resolving this would require passing a pre-verified authorization context into services rather than re-querying. Tracked as a future architectural improvement.
+
 ## How Route Handlers Use Services
 
 Route handlers remain thin and handle only:
+
 1. Authentication (check `event.context.user`)
 2. Input validation (Zod schemas)
 3. Transaction management
@@ -147,7 +160,10 @@ export default defineEventHandler(async (event) => {
 
         // 5. Error translation
         if (error instanceof UnauthorizedError) {
-            throw createError({ statusCode: 401, statusMessage: error.message });
+            throw createError({
+                statusCode: 401,
+                statusMessage: error.message,
+            });
         }
         if (error instanceof ValidationError) {
             throw createError({
@@ -242,6 +258,7 @@ server/services/
 **Phase 2 Completed (2025-11-17)** - See `vibes/251117_phase2-completion-report.md` for details.
 
 **Completed:**
+
 - ✅ Infrastructure files (`server/lib/types.ts`, `server/lib/errors.ts`)
 - ✅ ESLint rules for architecture enforcement
 - ✅ Service modules: `families.ts`, `invitations.ts`, `roles.ts`, `users.ts`, `auth.ts`
@@ -265,6 +282,7 @@ Phase 3: Security & Edge Cases (authorization testing, input validation, concurr
 ## Questions or Issues?
 
 Refer to:
+
 - **Detailed Plan:** `vibes/251114_service-layer-refactoring-plan.md`
 - **ESLint Rules:** `vibes/251117_eslint-rules-implemented.md`
 - **Original Issue:** GitHub issue #[number]

--- a/server/services/families.ts
+++ b/server/services/families.ts
@@ -10,6 +10,7 @@ import {
     ValidationError,
 } from "#server/lib/errors";
 import { logger } from "#server/utils/logger";
+import { isAdmin } from "#server/lib/authorization";
 
 /**
  * Creates a new family with the specified user as creator and manager.
@@ -179,4 +180,55 @@ export async function getUserFamilies(
                 notDeleted(families),
             ),
         );
+}
+
+/**
+ * Permanently deletes a family from the database (hard-delete).
+ *
+ * This is an admin-only operation. All related records (familyMembers,
+ * familyInvitations) are removed via ON DELETE CASCADE database constraints.
+ * This action is irreversible.
+ *
+ * @param dbConnection - Database connection (db or transaction)
+ * @param adminUserId - ID of the admin performing the deletion
+ * @param familyId - ID of the family to permanently delete
+ * @returns Object confirming deletion with the deleted family's ID
+ * @throws {UnauthorizedError} If adminUserId is not provided
+ * @throws {ForbiddenError} If the requesting user is not an admin
+ * @throws {NotFoundError} If the family does not exist
+ */
+export async function deleteFamily(
+    dbConnection: DbConnection,
+    adminUserId: string | null | undefined,
+    familyId: string,
+) {
+    if (!adminUserId) {
+        throw new UnauthorizedError("User not authenticated");
+    }
+
+    if (!(await isAdmin(dbConnection, adminUserId))) {
+        throw new ForbiddenError("User does not have admin privileges");
+    }
+
+    // Verify the family exists before attempting deletion
+    await findResourceOrThrow(
+        () =>
+            dbConnection.query.families.findFirst({
+                where: eq(families.id, familyId),
+            }),
+        "Family",
+    );
+
+    const [deletedFamily] = await dbConnection
+        .delete(families)
+        .where(eq(families.id, familyId))
+        .returning({ id: families.id });
+
+    if (!deletedFamily) {
+        throw new NotFoundError("Family not found");
+    }
+
+    logger.info(`Family hard-deleted: ${familyId} by admin ${adminUserId}`);
+
+    return { id: deletedFamily.id };
 }

--- a/server/services/families.ts
+++ b/server/services/families.ts
@@ -210,15 +210,6 @@ export async function deleteFamily(
         throw new ForbiddenError("User does not have admin privileges");
     }
 
-    // Verify the family exists before attempting deletion
-    await findResourceOrThrow(
-        () =>
-            dbConnection.query.families.findFirst({
-                where: eq(families.id, familyId),
-            }),
-        "Family",
-    );
-
     const [deletedFamily] = await dbConnection
         .delete(families)
         .where(eq(families.id, familyId))

--- a/server/services/users.ts
+++ b/server/services/users.ts
@@ -4,9 +4,9 @@ import type { DbConnection } from "#server/lib/types";
 import {
     InternalError,
     ConflictError,
+    NotFoundError,
     UnauthorizedError,
     ForbiddenError,
-    NotFoundError,
     ValidationError,
 } from "#server/lib/errors";
 import { logger } from "#server/utils/logger";

--- a/server/services/users.ts
+++ b/server/services/users.ts
@@ -6,11 +6,13 @@ import {
     ConflictError,
     UnauthorizedError,
     ForbiddenError,
+    NotFoundError,
     ValidationError,
 } from "#server/lib/errors";
 import { logger } from "#server/utils/logger";
 import { customHashPassword } from "#server/utils/password";
 import { isAdmin } from "#server/lib/authorization";
+import { findResourceOrThrow } from "#server/lib/validation";
 
 /**
  * Retrieves all users with their roles from the database.
@@ -197,4 +199,55 @@ export async function createUser(
         }
         throw error;
     }
+}
+
+/**
+ * Permanently deletes a user from the database (hard-delete).
+ *
+ * This is an admin-only operation. All related records (sessions, userRoles,
+ * familyMembers, userConsents) are removed via ON DELETE CASCADE database constraints.
+ * This action is irreversible.
+ *
+ * @param dbConnection - Database connection (db or transaction)
+ * @param adminUserId - ID of the admin performing the deletion
+ * @param targetUserId - ID of the user to permanently delete
+ * @returns Object confirming deletion with the deleted user's ID
+ * @throws {UnauthorizedError} If adminUserId is not provided
+ * @throws {ForbiddenError} If the requesting user is not an admin
+ * @throws {NotFoundError} If the target user does not exist
+ */
+export async function deleteUser(
+    dbConnection: DbConnection,
+    adminUserId: string | null | undefined,
+    targetUserId: string,
+) {
+    if (!adminUserId) {
+        throw new UnauthorizedError("User not authenticated");
+    }
+
+    if (!(await isAdmin(dbConnection, adminUserId))) {
+        throw new ForbiddenError("User does not have admin privileges");
+    }
+
+    // Verify the target user exists before attempting deletion
+    await findResourceOrThrow(
+        () =>
+            dbConnection.query.users.findFirst({
+                where: eq(users.id, targetUserId),
+            }),
+        "User",
+    );
+
+    const [deletedUser] = await dbConnection
+        .delete(users)
+        .where(eq(users.id, targetUserId))
+        .returning({ id: users.id });
+
+    if (!deletedUser) {
+        throw new NotFoundError("User not found");
+    }
+
+    logger.info(`User hard-deleted: ${targetUserId} by admin ${adminUserId}`);
+
+    return { id: deletedUser.id };
 }

--- a/server/services/users.ts
+++ b/server/services/users.ts
@@ -214,6 +214,7 @@ export async function createUser(
  * @returns Object confirming deletion with the deleted user's ID
  * @throws {UnauthorizedError} If adminUserId is not provided
  * @throws {ForbiddenError} If the requesting user is not an admin
+ * @throws {ForbiddenError} If the admin attempts to delete their own account
  * @throws {NotFoundError} If the target user does not exist
  */
 export async function deleteUser(
@@ -227,6 +228,11 @@ export async function deleteUser(
 
     if (!(await isAdmin(dbConnection, adminUserId))) {
         throw new ForbiddenError("User does not have admin privileges");
+    }
+
+    // Prevent admins from deleting their own account to avoid accidental lockouts
+    if (adminUserId === targetUserId) {
+        throw new ForbiddenError("Admin cannot delete their own account");
     }
 
     // Verify the target user exists before attempting deletion

--- a/server/services/users.ts
+++ b/server/services/users.ts
@@ -12,7 +12,6 @@ import {
 import { logger } from "#server/utils/logger";
 import { customHashPassword } from "#server/utils/password";
 import { isAdmin } from "#server/lib/authorization";
-import { findResourceOrThrow } from "#server/lib/validation";
 
 /**
  * Retrieves all users with their roles from the database.
@@ -234,15 +233,6 @@ export async function deleteUser(
     if (adminUserId === targetUserId) {
         throw new ForbiddenError("Admin cannot delete their own account");
     }
-
-    // Verify the target user exists before attempting deletion
-    await findResourceOrThrow(
-        () =>
-            dbConnection.query.users.findFirst({
-                where: eq(users.id, targetUserId),
-            }),
-        "User",
-    );
 
     const [deletedUser] = await dbConnection
         .delete(users)

--- a/test/nuxt/services/families.spec.ts
+++ b/test/nuxt/services/families.spec.ts
@@ -9,15 +9,24 @@ import {
     createFamily,
     getUserFamilies,
     transferOwnership,
+    deleteFamily,
 } from "#server/services/families";
 import { and, eq } from "drizzle-orm";
-import { families, familyMembers } from "~~/server/db/schema";
+import {
+    families,
+    familyMembers,
+    familyInvitations,
+} from "~~/server/db/schema";
 import {
     UnauthorizedError,
     ForbiddenError,
     ValidationError,
     NotFoundError,
 } from "#server/lib/errors";
+import {
+    createTestAdminUser,
+    createValidInvitation,
+} from "#test/utils/fixtures";
 
 describe("Family Service", () => {
     describe("createFamily", () => {
@@ -784,6 +793,101 @@ describe("Family Service", () => {
                     });
                     expect(dbFamily?.name).toBe(specialName);
                 });
+            });
+        });
+    });
+
+    describe("deleteFamily", () => {
+        it("should throw UnauthorizedError if admin user is not authenticated", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const owner = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+                await expect(deleteFamily(tx, null, family.id)).rejects.toThrow(
+                    UnauthorizedError,
+                );
+            });
+        });
+
+        it("should throw ForbiddenError if requesting user is not an admin", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const owner = await createTestUser(tx);
+                const nonAdmin = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+                await expect(
+                    deleteFamily(tx, nonAdmin.id, family.id),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
+        it("should throw NotFoundError when deleting a non-existent family", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const admin = await createTestAdminUser(tx);
+                await expect(
+                    deleteFamily(
+                        tx,
+                        admin.id,
+                        "00000000-0000-0000-0000-000000000000",
+                    ),
+                ).rejects.toThrow(NotFoundError);
+            });
+        });
+
+        it("should permanently delete a family", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const admin = await createTestAdminUser(tx);
+                const owner = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+
+                await deleteFamily(tx, admin.id, family.id);
+
+                const deletedFamily = await tx.query.families.findFirst({
+                    where: eq(families.id, family.id),
+                });
+                expect(deletedFamily).toBeUndefined();
+            });
+        });
+
+        it("should cascade-delete familyMembers when family is deleted", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const admin = await createTestAdminUser(tx);
+                const owner = await createTestUser(tx);
+                const member = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+
+                await tx.insert(familyMembers).values({
+                    family_id: family.id,
+                    user_id: member.id,
+                    role: "member",
+                });
+
+                await deleteFamily(tx, admin.id, family.id);
+
+                const remainingMembers = await tx.query.familyMembers.findMany({
+                    where: eq(familyMembers.family_id, family.id),
+                });
+                expect(remainingMembers).toHaveLength(0);
+            });
+        });
+
+        it("should cascade-delete familyInvitations when family is deleted", async () => {
+            await withTestTransaction(async (tx: TestTransaction) => {
+                const admin = await createTestAdminUser(tx);
+                const owner = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+
+                const invitation = await createValidInvitation(
+                    tx,
+                    family.id,
+                    owner.id,
+                );
+
+                await deleteFamily(tx, admin.id, family.id);
+
+                const remainingInvitation =
+                    await tx.query.familyInvitations.findFirst({
+                        where: eq(familyInvitations.id, invitation.id),
+                    });
+                expect(remainingInvitation).toBeUndefined();
             });
         });
     });

--- a/test/nuxt/services/families.spec.ts
+++ b/test/nuxt/services/families.spec.ts
@@ -3,7 +3,6 @@ import {
     withTestTransaction,
     createTestUser,
     createTestFamily,
-    type TestTransaction,
 } from "#test/utils";
 import {
     createFamily,
@@ -31,7 +30,7 @@ import {
 describe("Family Service", () => {
     describe("createFamily", () => {
         it("should create a family with the user as creator and manager", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 // 1. Setup: Create a test user
                 const user = await createTestUser(tx);
 
@@ -67,7 +66,7 @@ describe("Family Service", () => {
         });
 
         it("should throw an error if family creation fails", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 // Test with invalid user ID (non-existent)
                 await expect(
                     createFamily(tx, "non-existent-user-id", {
@@ -78,7 +77,7 @@ describe("Family Service", () => {
         });
 
         it("should create multiple families for the same user", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const user = await createTestUser(tx);
 
                 const family1 = await createFamily(tx, user.id, {
@@ -101,7 +100,7 @@ describe("Family Service", () => {
         describe("createFamily", () => {
             describe("Unauthenticated Access", () => {
                 it("should throw UnauthorizedError when userId is not provided (empty string)", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         await expect(
                             createFamily(tx, "", { name: "Test Family" }),
                         ).rejects.toThrow(UnauthorizedError);
@@ -109,7 +108,7 @@ describe("Family Service", () => {
                 });
 
                 it("should throw UnauthorizedError when userId is null", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         await expect(
                             createFamily(tx, null as unknown as string, {
                                 name: "Test Family",
@@ -119,7 +118,7 @@ describe("Family Service", () => {
                 });
 
                 it("should throw UnauthorizedError when userId is undefined", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         await expect(
                             createFamily(tx, undefined as unknown as string, {
                                 name: "Test Family",
@@ -133,7 +132,7 @@ describe("Family Service", () => {
         describe("transferOwnership", () => {
             describe("Insufficient Permissions", () => {
                 it("should throw ForbiddenError when user is a regular member (not creator)", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -175,7 +174,7 @@ describe("Family Service", () => {
                 });
 
                 it("should throw ForbiddenError when user is a manager (not creator)", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -219,7 +218,7 @@ describe("Family Service", () => {
 
             describe("Resource Ownership", () => {
                 it("should throw ForbiddenError when user is not the family creator", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -256,7 +255,7 @@ describe("Family Service", () => {
                 });
 
                 it("should allow creator to transfer ownership", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -293,7 +292,7 @@ describe("Family Service", () => {
 
             describe("Cross-Family Access Prevention", () => {
                 it("should throw ForbiddenError when user is creator of different family", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         // Create first family and its creator
                         const creator1 = await createTestUser(tx, {
                             email: "creator1@example.com",
@@ -340,7 +339,7 @@ describe("Family Service", () => {
                 });
 
                 it("should allow creator to only transfer ownership of their own family", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         // Create two families
                         const creator1 = await createTestUser(tx, {
                             email: "creator1@example.com",
@@ -404,7 +403,7 @@ describe("Family Service", () => {
 
             describe("Role-Based Access", () => {
                 it("should enforce that only creator can transfer (not manager role)", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -457,7 +456,7 @@ describe("Family Service", () => {
 
             describe("Soft-Deleted Resources", () => {
                 it("should throw NotFoundError when transferring ownership of a soft-deleted family", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -491,7 +490,7 @@ describe("Family Service", () => {
                 });
 
                 it("should throw ForbiddenError when soft-deleted creator attempts to transfer ownership", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -530,7 +529,7 @@ describe("Family Service", () => {
                 });
 
                 it("should throw ValidationError when soft-deleted member is designated as new owner", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -569,7 +568,7 @@ describe("Family Service", () => {
                 });
 
                 it("should exclude soft-deleted families from getUserFamilies", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const user = await createTestUser(tx);
                         const family = await createTestFamily(tx, user.id);
 
@@ -585,7 +584,7 @@ describe("Family Service", () => {
                 });
 
                 it("should exclude families where the user's membership is soft-deleted", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const user = await createTestUser(tx);
                         const family = await createTestFamily(tx, user.id);
 
@@ -608,7 +607,7 @@ describe("Family Service", () => {
 
             describe("getUserFamilies", () => {
                 it("should throw UnauthorizedError when userId is not provided", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         await expect(getUserFamilies(tx, null)).rejects.toThrow(
                             UnauthorizedError,
                         );
@@ -618,7 +617,7 @@ describe("Family Service", () => {
 
             describe("Business Rule Validation", () => {
                 it("should throw ValidationError when new owner is not a family member", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -644,7 +643,7 @@ describe("Family Service", () => {
                 });
 
                 it("should successfully transfer ownership when new owner is a member", async () => {
-                    await withTestTransaction(async (tx: TestTransaction) => {
+                    await withTestTransaction(async (tx) => {
                         const creator = await createTestUser(tx, {
                             email: "creator@example.com",
                             username: "creator",
@@ -686,7 +685,7 @@ describe("Family Service", () => {
     describe("Input Validation", () => {
         describe("createFamily", () => {
             it("should throw ValidationError if family name is less than 3 characters", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     await expect(
                         createFamily(tx, user.id, { name: "ab" }),
@@ -695,7 +694,7 @@ describe("Family Service", () => {
             });
 
             it("should throw ValidationError if family name exceeds maximum length (100 characters)", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const longName = "a".repeat(101); // Max length is 100
                     await expect(
@@ -709,7 +708,7 @@ describe("Family Service", () => {
     describe("Edge Cases", () => {
         describe("Non-Existent Resources", () => {
             it("should throw NotFoundError when transferring ownership of a non-existent family", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const anotherUser = await createTestUser(tx);
                     await expect(
@@ -724,7 +723,7 @@ describe("Family Service", () => {
             });
 
             it("should throw NotFoundError when transferring ownership to a non-existent user", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const family = await createTestFamily(tx, user.id);
                     await expect(
@@ -739,7 +738,7 @@ describe("Family Service", () => {
             });
 
             it("should throw ValidationError when transferring ownership with invalid UUID", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const anotherUser = await createTestUser(tx);
                     await expect(
@@ -756,7 +755,7 @@ describe("Family Service", () => {
 
         describe("Empty Collections", () => {
             it("should return an empty array when a user has no families", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
 
                     const result = await getUserFamilies(tx, user.id);
@@ -766,7 +765,7 @@ describe("Family Service", () => {
             });
 
             it("should return families the user is a member of", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const family = await createTestFamily(tx, user.id);
 
@@ -780,7 +779,7 @@ describe("Family Service", () => {
 
         describe("Unicode and Special Characters", () => {
             it("should create a family with Unicode and special characters in the name", async () => {
-                await withTestTransaction(async (tx: TestTransaction) => {
+                await withTestTransaction(async (tx) => {
                     const user = await createTestUser(tx);
                     const specialName = "Familie Müller 🎉-ケーニッヒ";
                     const family = await createFamily(tx, user.id, {
@@ -799,7 +798,7 @@ describe("Family Service", () => {
 
     describe("deleteFamily", () => {
         it("should throw UnauthorizedError if admin user is not authenticated", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const owner = await createTestUser(tx);
                 const family = await createTestFamily(tx, owner.id);
                 await expect(deleteFamily(tx, null, family.id)).rejects.toThrow(
@@ -809,7 +808,7 @@ describe("Family Service", () => {
         });
 
         it("should throw ForbiddenError if requesting user is not an admin", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const owner = await createTestUser(tx);
                 const nonAdmin = await createTestUser(tx);
                 const family = await createTestFamily(tx, owner.id);
@@ -820,7 +819,7 @@ describe("Family Service", () => {
         });
 
         it("should throw NotFoundError when deleting a non-existent family", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);
                 await expect(
                     deleteFamily(
@@ -833,7 +832,7 @@ describe("Family Service", () => {
         });
 
         it("should permanently delete a family", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);
                 const owner = await createTestUser(tx);
                 const family = await createTestFamily(tx, owner.id);
@@ -848,7 +847,7 @@ describe("Family Service", () => {
         });
 
         it("should cascade-delete familyMembers when family is deleted", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);
                 const owner = await createTestUser(tx);
                 const member = await createTestUser(tx);
@@ -870,7 +869,7 @@ describe("Family Service", () => {
         });
 
         it("should cascade-delete familyInvitations when family is deleted", async () => {
-            await withTestTransaction(async (tx: TestTransaction) => {
+            await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);
                 const owner = await createTestUser(tx);
                 const family = await createTestFamily(tx, owner.id);

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -8,7 +8,13 @@ import {
     createUser,
     deleteUser,
 } from "#server/services/users";
-import { sessions, userRoles, users, familyMembers } from "#server/db/schema";
+import {
+    sessions,
+    userRoles,
+    users,
+    families,
+    familyMembers,
+} from "#server/db/schema";
 import {
     UnauthorizedError,
     ForbiddenError,
@@ -374,6 +380,21 @@ describe("users service", () => {
                         where: eq(familyMembers.user_id, target.id),
                     });
                 expect(remainingMemberships).toHaveLength(0);
+            });
+        });
+
+        it("should cascade-delete families when creator user is deleted", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const creator = await createTestUser(tx);
+                const family = await createTestFamily(tx, creator.id);
+
+                await deleteUser(tx, admin.id, creator.id);
+
+                const deletedFamily = await tx.query.families.findFirst({
+                    where: eq(families.id, family.id),
+                });
+                expect(deletedFamily).toBeUndefined();
             });
         });
     });

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -2,13 +2,19 @@ import { describe, it, expect } from "vitest";
 import { eq } from "drizzle-orm";
 import { withTestTransaction } from "#test/utils/db";
 import { createTestUser, createTestAdminUser } from "#test/utils/fixtures";
-import { getAllUsersWithRoles, createUser } from "#server/services/users";
-import { users } from "#server/db/schema";
+import {
+    getAllUsersWithRoles,
+    createUser,
+    deleteUser,
+} from "#server/services/users";
+import { sessions, userRoles, users, familyMembers } from "#server/db/schema";
 import {
     UnauthorizedError,
     ForbiddenError,
+    NotFoundError,
     ValidationError,
 } from "#server/lib/errors";
+import { createTestFamily } from "#test/utils/fixtures";
 
 describe("users service", () => {
     describe("getAllUsersWithRoles", () => {
@@ -246,6 +252,117 @@ describe("users service", () => {
                         password: "password123",
                     }),
                 ).rejects.toThrow(ForbiddenError);
+            });
+        });
+    });
+
+    describe("deleteUser", () => {
+        it("should throw UnauthorizedError if admin user is not authenticated", async () => {
+            await withTestTransaction(async (tx) => {
+                const target = await createTestUser(tx);
+                await expect(deleteUser(tx, null, target.id)).rejects.toThrow(
+                    UnauthorizedError,
+                );
+            });
+        });
+
+        it("should throw ForbiddenError if requesting user is not an admin", async () => {
+            await withTestTransaction(async (tx) => {
+                const nonAdmin = await createTestUser(tx);
+                const target = await createTestUser(tx);
+                await expect(
+                    deleteUser(tx, nonAdmin.id, target.id),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
+        it("should throw NotFoundError when deleting a non-existent user", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                await expect(
+                    deleteUser(
+                        tx,
+                        admin.id,
+                        "00000000-0000-0000-0000-000000000000",
+                    ),
+                ).rejects.toThrow(NotFoundError);
+            });
+        });
+
+        it("should permanently delete a user", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const target = await createTestUser(tx);
+
+                await deleteUser(tx, admin.id, target.id);
+
+                const deletedUser = await tx.query.users.findFirst({
+                    where: eq(users.id, target.id),
+                });
+                expect(deletedUser).toBeUndefined();
+            });
+        });
+
+        it("should cascade-delete userRoles when user is deleted", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const target = await createTestUser(tx);
+
+                const rolesBeforeDelete = await tx.query.userRoles.findMany({
+                    where: eq(userRoles.user_id, target.id),
+                });
+                expect(rolesBeforeDelete.length).toBeGreaterThanOrEqual(0);
+
+                await deleteUser(tx, admin.id, target.id);
+
+                const rolesAfterDelete = await tx.query.userRoles.findMany({
+                    where: eq(userRoles.user_id, target.id),
+                });
+                expect(rolesAfterDelete).toHaveLength(0);
+            });
+        });
+
+        it("should cascade-delete sessions when user is deleted", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const target = await createTestUser(tx);
+
+                await tx.insert(sessions).values({
+                    user_id: target.id,
+                    ip_address: "127.0.0.1",
+                    user_agent: "test-agent",
+                    expires_at: new Date(Date.now() + 86400000),
+                });
+
+                await deleteUser(tx, admin.id, target.id);
+
+                const remainingSessions = await tx.query.sessions.findMany({
+                    where: eq(sessions.user_id, target.id),
+                });
+                expect(remainingSessions).toHaveLength(0);
+            });
+        });
+
+        it("should cascade-delete familyMembers when user is deleted", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const owner = await createTestUser(tx);
+                const target = await createTestUser(tx);
+                const family = await createTestFamily(tx, owner.id);
+
+                await tx.insert(familyMembers).values({
+                    family_id: family.id,
+                    user_id: target.id,
+                    role: "member",
+                });
+
+                await deleteUser(tx, admin.id, target.id);
+
+                const remainingMemberships =
+                    await tx.query.familyMembers.findMany({
+                        where: eq(familyMembers.user_id, target.id),
+                    });
+                expect(remainingMemberships).toHaveLength(0);
             });
         });
     });

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -277,6 +277,15 @@ describe("users service", () => {
             });
         });
 
+        it("should throw ForbiddenError when admin tries to delete their own account", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                await expect(
+                    deleteUser(tx, admin.id, admin.id),
+                ).rejects.toThrow(ForbiddenError);
+            });
+        });
+
         it("should throw NotFoundError when deleting a non-existent user", async () => {
             await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { withTestTransaction } from "#test/utils/db";
 import { createTestUser, createTestAdminUser } from "#test/utils/fixtures";
@@ -329,6 +330,7 @@ describe("users service", () => {
 
                 await tx.insert(sessions).values({
                     user_id: target.id,
+                    token: randomUUID(),
                     ip_address: "127.0.0.1",
                     user_agent: "test-agent",
                     expires_at: new Date(Date.now() + 86400000),

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
 import { withTestTransaction } from "#test/utils/db";
-import { createTestUser, createTestAdminUser } from "#test/utils/fixtures";
+import {
+    createTestUser,
+    createTestAdminUser,
+    createTestUserWithRole,
+} from "#test/utils/fixtures";
 import {
     getAllUsersWithRoles,
     createUser,
@@ -322,12 +326,12 @@ describe("users service", () => {
         it("should cascade-delete userRoles when user is deleted", async () => {
             await withTestTransaction(async (tx) => {
                 const admin = await createTestAdminUser(tx);
-                const target = await createTestUser(tx);
+                const target = await createTestUserWithRole(tx, "member");
 
                 const rolesBeforeDelete = await tx.query.userRoles.findMany({
                     where: eq(userRoles.user_id, target.id),
                 });
-                expect(rolesBeforeDelete.length).toBeGreaterThanOrEqual(0);
+                expect(rolesBeforeDelete).toHaveLength(1);
 
                 await deleteUser(tx, admin.id, target.id);
 

--- a/test/nuxt/services/users.spec.ts
+++ b/test/nuxt/services/users.spec.ts
@@ -15,6 +15,7 @@ import {
 import {
     sessions,
     userRoles,
+    userConsents,
     users,
     families,
     familyMembers,
@@ -399,6 +400,26 @@ describe("users service", () => {
                     where: eq(families.id, family.id),
                 });
                 expect(deletedFamily).toBeUndefined();
+            });
+        });
+
+        it("should cascade-delete userConsents when user is deleted", async () => {
+            await withTestTransaction(async (tx) => {
+                const admin = await createTestAdminUser(tx);
+                const target = await createTestUser(tx);
+
+                await tx.insert(userConsents).values({
+                    user_id: target.id,
+                    consent_type: "data_processing",
+                    granted: true,
+                });
+
+                await deleteUser(tx, admin.id, target.id);
+
+                const remainingConsents = await tx.query.userConsents.findMany({
+                    where: eq(userConsents.user_id, target.id),
+                });
+                expect(remainingConsents).toHaveLength(0);
             });
         });
     });


### PR DESCRIPTION
## Summary

- Implement `deleteUser()` and `deleteFamily()` service functions (admin-only), relying on `ON DELETE CASCADE` for referential cleanup of related records (sessions, userRoles, familyMembers, familyInvitations, userConsents)
- Refactor `DELETE /api/admin/users/:id` route to use the new service layer, removing inline delete logic and a redundant manual `userRoles` cleanup
- Add `DELETE /api/admin/families/:id` route (new endpoint)
- Export `InternalError` from `#server/lib/errors` (was used in `roles.ts` and `users.ts` but missing from the module)
- Add 13 service-layer tests covering auth guards (Unauthorized/Forbidden), self-deletion guard, NotFoundError for missing resources, permanent removal verification, and cascade checks for `userRoles`, `sessions`, `familyMembers`, `familyInvitations`, and `userConsents`

## Response shape change

`DELETE /api/admin/users/:id` previously returned `{ message }`. It now returns `{ message, id }` — an additive change that aligns it with the new `DELETE /api/admin/families/:id` endpoint, which also returns `{ message, id }`. No existing callers depend on the old shape.

## Related

Closes #67